### PR TITLE
chore: approve esbuild/sharp native build scripts for pnpm 11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+# pnpm 11 blocks dependency build scripts by default. esbuild and sharp
+# (used by Astro/Vite and image optimization) ship native binaries via
+# postinstall, so a fresh `pnpm install` exits non-zero until they're
+# approved — which breaks `astro build`'s dependency pre-flight in CI and
+# on clean checkouts. Approving them here keeps installs non-interactive.
+allowBuilds:
+  esbuild: true
+  sharp: true
+onlyBuiltDependencies:
+  - esbuild
+  - sharp


### PR DESCRIPTION
## Summary
Adds `pnpm-workspace.yaml` approving the native build scripts for **esbuild** and **sharp**.

## Why
pnpm 11 blocks dependency build scripts by default. esbuild (via Astro/Vite) and sharp (image optimization) ship native binaries through `postinstall`, so a fresh `pnpm install` exits non-zero on the pending approval prompt. That non-zero exit breaks `astro build`'s dependency pre-flight (`runDepsStatusCheck`) on clean checkouts and in CI — the build fails before it starts.

Approving them here keeps installs fully non-interactive.

## Verification
On a clean tree (`rm -rf node_modules dist`):
- `pnpm install` → exit 0, esbuild/sharp postinstall scripts run
- `pnpm build` → exit 0, 38 pages built

## Note
Independent of #6 (design guide + font tokens); this is config-only, branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F76pBUys6cmHzoYTi31sFZ