### PR TITLE
feat(profile): centralizar datos personales en src/data/profile.ts

### DIFF
--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -1,11 +1,12 @@
 ---
 import CallToAction from './CallToAction.astro';
 import Icon from './Icon.astro';
+import { profile } from '../data/profile';
 ---
 
 <aside>
 	<h2>¿Interesado en trabajar juntos?</h2>
-	<CallToAction href="mailto:luisafernandabenitezariza@gmail.com">
+	<CallToAction href={`mailto:${profile.email}`}>
 		Envíame un mensaje
 		<Icon icon="paper-plane-tilt" size="1.2em" />
 	</CallToAction>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,15 +1,16 @@
 ---
 import Icon from './Icon.astro';
+import { profile } from '../data/profile';
 
 const currentYear = new Date().getFullYear();
 ---
 
 <footer>
 	<div class="group">
-		<p>&copy; {currentYear} Luisa Benítez</p>
+		<p>&copy; {currentYear} {profile.name}</p>
 	</div>
 	<p class="socials">
-		<a href="https://instagram.com/luisabeniteza/" target="_blank" rel="noopener noreferrer">Instagram <span class="sr-only">(se abre en una pestaña nueva)</span></a>
+		<a href={profile.instagram.url} target="_blank" rel="noopener noreferrer">Instagram <span class="sr-only">(se abre en una pestaña nueva)</span></a>
 	</p>
 </footer>
 <style>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -2,6 +2,7 @@
 import Icon from './Icon.astro';
 import type { iconPaths } from './IconPaths';
 import ThemeToggle from './ThemeToggle.astro';
+import { profile } from '../data/profile';
 
 /** Main menu items */
 const textLinks: { label: string; href: string }[] = [
@@ -13,9 +14,9 @@ const textLinks: { label: string; href: string }[] = [
 	{ label: 'Runway', href: '/runway/' },
 ];
 
-/** Icon links to social media — edit these with links to your profiles! */
+/** Icon links to social media — sourced from src/data/profile.ts */
 const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[] = [
-	{ label: 'Instagram', href: 'https://instagram.com/luisabeniteza/', icon: 'instagram-logo' },
+	{ label: 'Instagram', href: profile.instagram.url, icon: 'instagram-logo' },
 ];
 
 /** Test if a link is pointing to the current page. */
@@ -32,7 +33,7 @@ const activeLink = textLinks.find((link) => isCurrentPage(link.href));
 	<div class="menu-header">
 		<div class="stack gap-1">
 			<a href="/" class="site-title">
-				Luisa Benítez
+				{profile.name}
 				{
 					activeLink && activeLink.href !== "/" && (
 						<span class="mobile-page-label">
@@ -41,7 +42,7 @@ const activeLink = textLinks.find((link) => isCurrentPage(link.href));
 					)
 				}
 			</a>
-			<p class="tagline font-freehand text-lg">Fashion Stylist</p>
+			<p class="tagline font-freehand text-lg">{profile.role}</p>
 		</div>
 		<menu-button>
 			<template>

--- a/src/data/profile.ts
+++ b/src/data/profile.ts
@@ -1,0 +1,50 @@
+/**
+ * Fuente única de verdad para los datos personales de Luisa.
+ *
+ * Cualquier dato de contacto, redes, servicios o medios debe vivir aquí y
+ * consumirse desde los componentes/páginas — nunca hardcodearse en el markup.
+ *
+ * Nota i18n: los textos de cara al usuario (`role`, `languages`, `services`)
+ * están en español. Cuando entre la Fase 4 (#38) se moverán a `src/i18n/`.
+ */
+export const profile = {
+	name: 'Luisa Benítez',
+	role: 'Fashion Stylist',
+	baseCity: 'Madrid',
+	availableForTravel: true,
+	languages: ['Español (nativo)', 'Inglés'],
+
+	/** TODO(#17): cambiar a hello@luisabenitez.es cuando H-7 (#14) resuelva el backend de email. */
+	email: 'luisafernandabenitezariza@gmail.com',
+
+	instagram: {
+		handle: '@luisabeniteza',
+		url: 'https://instagram.com/luisabeniteza/',
+	},
+
+	/** TODO(H-2 / #9): rellenar si Luisa confirma perfil de LinkedIn. */
+	linkedin: undefined as string | undefined,
+
+	/** TODO(H-3 / #10): los PDFs aún no existen en public/cv/. */
+	cvPath: {
+		es: '/cv/luisa-benitez-cv-es.pdf',
+		en: '/cv/luisa-benitez-cv-en.pdf',
+	},
+
+	services: [
+		'Estilismo editorial',
+		'Estilismo de campaña y lookbook',
+		'Vestuario de celebridades',
+		'Asesoría de imagen',
+		'Personal shopping',
+	],
+
+	/** TODO(H-5 / #12): confirmar lista definitiva con Luisa. */
+	featuredIn: [
+		'Vogue Adria',
+		'Numéro',
+		'GQ México',
+		'Mode Magazine',
+		'Fucking Young',
+	],
+} as const;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,7 @@ import Icon from "../components/Icon.astro";
 import PortfolioPreview from "../components/PortfolioPreview.astro";
 
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { profile } from "../data/profile";
 
 const projects = (await getCollection("work"))
 	.sort((a, b) => a.data.order - b.data.order)
@@ -37,13 +38,13 @@ const projects = (await getCollection("work"))
 							fetchpriority="high"
 						/>
 						<a
-							href="https://instagram.com/luisabeniteza/"
+							href={profile.instagram.url}
 							target="_blank"
 							rel="noopener noreferrer"
 							class="instagram-link"
 						>
 							<Icon icon="instagram-logo" size="1.5em" />
-							@luisabeniteza
+							{profile.instagram.handle}
 						</a>
 					</div>
 				</Hero>


### PR DESCRIPTION
Cierra #30 (`P3-1`) — primer issue de la Fase 3.

## Qué hace

Crea `src/data/profile.ts` como fuente única de verdad (nombre, rol, ciudad, idiomas, email, Instagram, LinkedIn, CV, servicios, `featuredIn`) y refactoriza los consumidores que hasta ahora duplicaban esos valores en el markup.

Duplicación eliminada:

| Dato | Estaba en |
|---|---|
| Instagram | `Footer.astro`, `Nav.astro`, `index.astro` — 3 sitios |
| Email | `ContactCTA.astro` |
| Nombre / rol | `Footer.astro`, `Nav.astro` |

## Decisiones tomadas

- **Email**: se mantiene el Gmail actual. Cambiar a `hello@luisabenitez.es` queda reducido a una línea cuando #17 / H-7 (#14) resuelvan backend y DNS.
- **Idioma**: textos de cara al usuario en español, coherente con el sitio. Se moverán a `src/i18n/` en la Fase 4 (#38).
- Campos que dependen de inputs humanos van con `TODO`: LinkedIn (H-2), `cvPath` (H-3 / #10), `featuredIn` (H-5 / #12). No bloquean.

## Verificación

`pnpm build` verde, 38 páginas. Comparado el `dist/` contra un build de `origin/main` en worktree aislado:

- **37 de 38 páginas byte-idénticas** (ignorando espacios en blanco).
- `index.html`: única diferencia es que el bloque `<style>` scoped de la página pasa a emitirse **después** del `<link>` al CSS global en vez de antes. El CSS es idéntico; solo cambia el orden por el nuevo import. Sin impacto visual — todas esas reglas llevan selector `[data-astro-cid-…]`, así que ya ganaban por especificidad.

## Nota aparte (no bloqueante, no es de este PR)

Al comparar builds salió que **Tailwind está escaneando `docs/`**: palabras sueltas en la prosa (`visible`, `table`, `italic`, `absolute`, `blur`) generan utilities muertas en el bundle. Hoy no afecta a producción porque esos docs están sin trackear, pero en cuanto se commiteen sí entrarán. Vale la pena acotar el `content` glob de Tailwind a `src/` — ¿abro issue?

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFYBEyKKn8uG2tpGivSywo