### PR TITLE
chore(ci): fijar la versión de pnpm en package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "portfolio",
   "type": "module",
   "version": "0.0.1",
+  "packageManager": "pnpm@11.15.0",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
Primero de los dos avisos que salen en el build del deploy.

## Qué arregla

Sin campo `packageManager`, la acción de despliegue instala **«la última versión de pnpm»** y lo avisa en cada build. Eso significa que CI puede acabar construyendo con una versión distinta a la de desarrollo sin que nadie se entere — el tipo de divergencia que aparece como un fallo raro meses después.

Fijado a `pnpm@11.15.0`, la que se usa en local y la que generó el lockfile.

## Verificación

`pnpm install --frozen-lockfile` (lo que ejecuta CI) y `pnpm build` en verde con el campo nuevo. Lockfile sin cambios.

## ⚠️ El segundo aviso no va en este PR

El de **deprecación de Node 20** no viene de este repo: lo emiten `actions/upload-artifact` y `pnpm/action-setup`, ambas **internas de `withastro/action@v5`**. Se arregla subiendo esa acción a v6, no tocando nuestro workflow.

No puedo incluirlo aquí porque **mi token no tiene scope `workflow`** y GitHub rechaza el push a `.github/workflows/`. El cambio es una línea, en el comentario del PR está el diff exacto para aplicarlo a mano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFYBEyKKn8uG2tpGivSywo