### PR TITLE
fix(contact): alinear los colores de texto con el resto del sitio

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -137,18 +137,20 @@ const details: { label: string; value: string }[] = [
 		object-fit: cover;
 		/* Descentrado a propósito: centrado deja un encuadre de foto de carnet. */
 		object-position: 50% 22%;
+		/* Solo se difumina abajo, donde la foto funde con el texto. Arriba se
+		   quitó: peleaba con el edificio claro del propio encuadre y en modo
+		   claro se leía como niebla sobre la imagen. El borde superior contra
+		   el nav es un límite deliberado. */
 		-webkit-mask-image: linear-gradient(
 			to bottom,
-			transparent 0%,
-			#000 7%,
-			#000 68%,
+			#000 0%,
+			#000 70%,
 			transparent 100%
 		);
 		mask-image: linear-gradient(
 			to bottom,
-			transparent 0%,
-			#000 7%,
-			#000 68%,
+			#000 0%,
+			#000 70%,
 			transparent 100%
 		);
 	}
@@ -168,7 +170,7 @@ const details: { label: string; value: string }[] = [
 		font-size: var(--text-base);
 		letter-spacing: 0.3em;
 		text-transform: uppercase;
-		color: var(--gray-400);
+		color: var(--gray-100);
 	}
 
 	.headline {
@@ -185,7 +187,7 @@ const details: { label: string; value: string }[] = [
 		max-width: 34ch;
 		font-size: var(--text-md);
 		line-height: 1.6;
-		color: var(--gray-300);
+		color: var(--gray-50);
 	}
 
 	.channels {
@@ -210,7 +212,7 @@ const details: { label: string; value: string }[] = [
 		font-size: var(--text-sm);
 		letter-spacing: 0.25em;
 		text-transform: uppercase;
-		color: var(--gray-400);
+		color: var(--gray-100);
 	}
 
 	.channel-value {
@@ -269,14 +271,14 @@ const details: { label: string; value: string }[] = [
 		font-size: var(--text-sm);
 		letter-spacing: 0.25em;
 		text-transform: uppercase;
-		color: var(--gray-400);
+		color: var(--gray-100);
 	}
 
 	.detail-value {
 		margin: 0;
 		font-size: var(--text-base);
 		line-height: 1.4;
-		color: var(--gray-300);
+		color: var(--gray-50);
 	}
 
 	.cv {


### PR DESCRIPTION
Detectado validando `/contact` en un móvil real.

## 1. El texto era de otro color

Medido con el navegador, comparando el color computado:

| | `/contact` | Resto del sitio |
|---|---|---|
| Párrafo, claro | `rgb(80,93,132)` | `rgb(20,25,37)` |
| Párrafo, oscuro | `rgb(163,172,200)` | `rgb(243,244,247)` |

Usaba `--gray-300` y `--gray-400`. **La rampa neutra de este design system tiene tinte azul**, y en los pasos intermedios ese azul se ve; el resto del sitio usa `--gray-50`, que al estar en el extremo se lee como casi negro o casi blanco.

Cuerpo a `--gray-50` y etiquetas a `--gray-100` — un paso más apagadas, sin virar a azul. Verificado: ahora computan exactamente los mismos valores que la home.

## 2. Fuera el difuminado del borde superior

Peleaba con el edificio claro del propio encuadre y en modo claro se leía como niebla sobre la foto. Abajo se mantiene, porque ahí la imagen sí funde con el texto. El borde superior contra el nav queda como un límite deliberado.

Esto también resuelve lo del modo claro, que era en buena parte el mismo problema: texto azulado + neblina en la foto.

## No incluido a propósito

El wordmark parte en dos líneas a 390 px y deja el `|` de la etiqueta en una línea suelta. **No lo causa esta página**: pasa igual en `/editorials/`, `/celebrities/` y `/publicity/` — todas dan 57 px de alto y 2 líneas. Es comportamiento del nav en móvil, así que va a #53 en vez de meter aquí otro cambio global.

## Verificación

Build en verde, 39 páginas. Solo cambia `src/pages/contact.astro`. Capturas revisadas en 390×844 en los dos temas.

Refs #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFYBEyKKn8uG2tpGivSywo