### PR TITLE
feat(footer): añadir email y LinkedIn opcional desde profile.ts

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,8 +1,16 @@
 ---
-import Icon from './Icon.astro';
 import { profile } from '../data/profile';
 
 const currentYear = new Date().getFullYear();
+
+/** Vías de contacto del footer, todas desde profile.ts. LinkedIn solo si existe. */
+const links: { label: string; href: string; external?: boolean }[] = [
+	{ label: 'Email', href: `mailto:${profile.email}` },
+	{ label: 'Instagram', href: profile.instagram.url, external: true },
+	...(profile.linkedin
+		? [{ label: 'LinkedIn', href: profile.linkedin, external: true }]
+		: []),
+];
 ---
 
 <footer>
@@ -10,7 +18,18 @@ const currentYear = new Date().getFullYear();
 		<p>&copy; {currentYear} {profile.name}</p>
 	</div>
 	<p class="socials">
-		<a href={profile.instagram.url} target="_blank" rel="noopener noreferrer">Instagram <span class="sr-only">(se abre en una pestaña nueva)</span></a>
+		{
+			links.map(({ label, href, external }) => (
+				<a
+					href={href}
+					target={external ? '_blank' : undefined}
+					rel={external ? 'noopener noreferrer' : undefined}
+				>
+					{label}
+					{external && <span class="sr-only"> (se abre en una pestaña nueva)</span>}
+				</a>
+			))
+		}
 	</p>
 </footer>
 <style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,14 +1,16 @@
 ---
+import Icon from './Icon.astro';
+import type { iconPaths } from './IconPaths';
 import { profile } from '../data/profile';
 
 const currentYear = new Date().getFullYear();
 
-/** Vías de contacto del footer, todas desde profile.ts. LinkedIn solo si existe. */
-const links: { label: string; href: string; external?: boolean }[] = [
-	{ label: 'Email', href: `mailto:${profile.email}` },
-	{ label: 'Instagram', href: profile.instagram.url, external: true },
+/** Canales del footer como iconos, todos desde profile.ts. LinkedIn solo si existe. */
+const socials: { label: string; href: string; icon: keyof typeof iconPaths; external?: boolean }[] = [
+	{ label: 'Email', href: `mailto:${profile.email}`, icon: 'paper-plane-tilt' },
+	{ label: 'Instagram', href: profile.instagram.url, icon: 'instagram-logo', external: true },
 	...(profile.linkedin
-		? [{ label: 'LinkedIn', href: profile.linkedin, external: true }]
+		? [{ label: 'LinkedIn', href: profile.linkedin, icon: 'linkedin-logo' as const, external: true }]
 		: []),
 ];
 ---
@@ -17,43 +19,36 @@ const links: { label: string; href: string; external?: boolean }[] = [
 	<div class="group">
 		<p>&copy; {currentYear} {profile.name}</p>
 	</div>
-	<p class="socials">
+	<div class="socials">
 		{
-			links.map(({ label, href, external }) => (
+			socials.map(({ label, href, icon, external }) => (
 				<a
 					href={href}
+					class="social"
 					target={external ? '_blank' : undefined}
 					rel={external ? 'noopener noreferrer' : undefined}
 				>
-					{label}
-					{external && <span class="sr-only"> (se abre en una pestaña nueva)</span>}
+					<span class="sr-only">
+						{label}
+						{external && ' (se abre en una pestaña nueva)'}
+					</span>
+					<Icon icon={icon} />
 				</a>
 			))
 		}
-	</p>
+	</div>
 </footer>
 <style>
 	footer {
 		display: flex;
 		flex-direction: column;
-		gap: 1rem;
+		gap: 1.25rem;
 		margin-top: auto;
 		padding: 3rem 2rem 3rem;
+		align-items: center;
 		text-align: center;
 		color: var(--gray-0);
 		font-size: var(--text-sm);
-	}
-
-	footer a {
-		color: var(--gray-0);
-		text-decoration: 1px solid underline transparent;
-		text-underline-offset: 0.25em;
-		transition: text-decoration-color var(--theme-transition);
-	}
-
-	footer a:hover,
-	footer a:focus {
-		text-decoration-color: currentColor;
 	}
 
 	.group {
@@ -63,16 +58,38 @@ const links: { label: string; href: string; external?: boolean }[] = [
 	}
 
 	.socials {
+		--icon-size: var(--text-xl);
+		--icon-padding: 0.5rem;
+
 		display: flex;
 		justify-content: center;
-		gap: 1rem;
-		flex-wrap: wrap;
+		gap: 0.5rem;
+		font-size: var(--icon-size);
+	}
+
+	.social {
+		display: flex;
+		padding: var(--icon-padding);
+		color: var(--gray-0);
+		text-decoration: none;
+		transition: color var(--theme-transition);
+	}
+
+	.social:hover,
+	.social:focus-visible {
+		color: var(--accent-regular);
+	}
+
+	:global(.theme-dark) .social:hover,
+	:global(.theme-dark) .social:focus-visible {
+		color: var(--accent-dark);
 	}
 
 	@media (min-width: 50em) {
 		footer {
 			flex-direction: row;
 			justify-content: space-between;
+			align-items: center;
 			padding: 2.5rem 5rem;
 		}
 
@@ -80,10 +97,6 @@ const links: { label: string; href: string; external?: boolean }[] = [
 			flex-direction: row;
 			gap: 1rem;
 			flex-wrap: wrap;
-		}
-
-		.socials {
-			justify-content: flex-end;
 		}
 	}
 </style>


### PR DESCRIPTION
Cierra #34 (`P3-5`).

## Qué hace

El footer ya mostraba Instagram y el nombre desde `profile.ts` (#51). Este PR:

- Añade **Email** y **LinkedIn** (LinkedIn condicionado a que exista en `profile` — hoy `undefined` por H-2, así que no se pinta)
- Los canales se muestran como **iconos**, a juego con el nav
- Todo se genera por `map` desde `profile.ts`

## La decisión del email

Instagram y LinkedIn tienen logo de marca; el email no, y el set no tiene icono de sobre. Se usa `paper-plane-tilt`. Es ambiguo a la vista —se lee como «enviar»— pero la etiqueta `sr-only` dice «Email», así que los lectores de pantalla lo anuncian correctamente. Elegido sobre captura frente a las alternativas (email escrito, o icono+etiqueta).

## Sobre la tipografía del chrome — corrijo un error mío

En sesiones anteriores dije que el footer desentonaba porque iba en `system-ui` mientras el nav iba en Bebas. **Lo medí en el navegador y es falso: los dos son `system-ui`.** No hay incoherencia de fuente entre nav y footer. La cuestión real (que el wordmark adopte Bebas, como pide el design system) es un cambio de nav y queda en #53.

## Verificación

Build en verde. Diff del `dist/` contra `origin/main`: el único cambio en las 39 páginas está dentro del `<footer>` (los iconos de canal). Capturas revisadas en claro y oscuro, escritorio y móvil.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFYBEyKKn8uG2tpGivSywo