### PR TITLE
feat(i18n): cimientos de i18n — config Astro + módulo src/i18n

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,21 @@ import sitemap from '@astrojs/sitemap';
 export default defineConfig({
   site: 'https://luisabenitez.es',
   base: '/',
+  // Cimientos de i18n (P4-1). El español vive en la raíz y el inglés vivirá
+  // bajo /en/. Mientras no existan páginas en src/pages/en/, esta config es
+  // inerte: no genera ni cambia ninguna ruta.
+  //
+  // El `fallback: { en: 'es' }` del handoff se deja para MÁS ADELANTE (P4-5,
+  // las páginas espejo): habilitarlo ahora, sin ninguna página EN, hace que
+  // Astro genere 39 stubs de redirect /en/* → / que se indexarían sin aportar
+  // nada. El fallback solo tiene sentido cuando ya hay páginas EN de las que caer.
+  i18n: {
+    defaultLocale: 'es',
+    locales: ['es', 'en'],
+    routing: {
+      prefixDefaultLocale: false, // ES en la raíz, EN en /en/
+    },
+  },
   integrations: [sitemap()],
   devToolbar: {
     enabled: false

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,0 +1,44 @@
+import type { Translation } from './es';
+
+/**
+ * Strings en inglés. El tipo `Translation` obliga a tener EXACTAMENTE las
+ * mismas claves que es.ts: si falta una, o sobra, TypeScript falla. Los
+ * valores son libres (es una traducción). La prosa larga y las categorías de
+ * la Fase 2 se traducirán cuando el contenido en español esté cerrado.
+ */
+export const en: Translation = {
+	meta: {
+		siteTitle: 'Luisa Benítez — Fashion Stylist & Image Consultant',
+		siteDescription:
+			'Portfolio of Luisa Benítez — fashion stylist, image consultant and personal shopper. Editorial, campaigns, celebrity dressing, runway and film work.',
+	},
+	nav: {
+		home: 'Home',
+		editorial: 'Editorial',
+		publicity: 'Campaigns',
+		celebrities: 'Celebrities',
+		films: 'Film & TV',
+		runway: 'Runway',
+		contact: 'Contact',
+	},
+	contact: {
+		eyebrow: 'Contact',
+		title: "Let's talk",
+		lead: 'For editorial, campaign, or celebrity styling enquiries.',
+		metaDescription:
+			'Get in touch with Luisa Benítez, fashion stylist and image consultant, for editorial, campaign or celebrity styling enquiries.',
+	},
+	channels: {
+		email: 'Email',
+		instagram: 'Instagram',
+		linkedin: 'LinkedIn',
+	},
+	details: {
+		base: 'Based in',
+		languages: 'Languages',
+	},
+	common: {
+		downloadCv: 'Download CV',
+		newWindowHint: '(opens in a new tab)',
+	},
+};

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -1,0 +1,66 @@
+/**
+ * Strings en español — el idioma por defecto del sitio.
+ *
+ * `es.ts` es la fuente de la verdad: define la FORMA del diccionario. El tipo
+ * `Translation` (derivado de aquí) obliga a que en.ts tenga exactamente las
+ * mismas claves, así que al añadir una aquí TypeScript la exige también en
+ * inglés. Los VALORES pueden diferir (para eso es una traducción); lo que se
+ * comparte es la estructura.
+ *
+ * Alcance de P4-2: solo los strings de UI que ya existen en el sitio hoy. La
+ * prosa larga (About, descripciones de proyecto) y las categorías renombradas
+ * de la Fase 2 llegan cuando ese contenido esté cerrado (P4-3, P4-4).
+ */
+export const es = {
+	meta: {
+		siteTitle: 'Luisa Benítez — Estilista y Asesora de Imagen',
+		siteDescription:
+			'Portfolio de Luisa Benítez, estilista y asistente de moda, diseñadora de modas, asesora de imagen y personal shopper. Descubre sus trabajos en editoriales, publicidad, pasarela y cine.',
+	},
+	nav: {
+		home: 'Inicio',
+		editorial: 'Editorial',
+		publicity: 'Publicidad',
+		celebrities: 'Celebridades',
+		films: 'Cine',
+		runway: 'Runway',
+		contact: 'Contacto',
+	},
+	contact: {
+		eyebrow: 'Contacto',
+		title: 'Hablemos',
+		lead: 'Para encargos editoriales, campañas o vestuario de celebridades.',
+		metaDescription:
+			'Contacta con Luisa Benítez, estilista y asesora de imagen, para encargos editoriales, campañas o vestuario de celebridades.',
+	},
+	channels: {
+		email: 'Email',
+		instagram: 'Instagram',
+		linkedin: 'LinkedIn',
+	},
+	details: {
+		base: 'Base',
+		languages: 'Idiomas',
+	},
+	common: {
+		downloadCv: 'Descargar CV',
+		newWindowHint: '(se abre en una pestaña nueva)',
+	},
+} as const;
+
+/**
+ * Ensancha los literales a su primitivo, de forma recursiva. Así el tipo del
+ * diccionario describe la estructura ("cada hoja es un string") sin clavar el
+ * valor español. es.ts (con `as const`) encaja porque un literal es asignable
+ * a su primitivo; en.ts debe tener las mismas claves con valores string.
+ */
+type Widen<T> = T extends string
+	? string
+	: T extends number
+		? number
+		: T extends boolean
+			? boolean
+			: { [K in keyof T]: Widen<T[K]> };
+
+/** Forma que deben cumplir todos los diccionarios de idioma. */
+export type Translation = Widen<typeof es>;

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,29 @@
+import { es, type Translation } from './es';
+import { en } from './en';
+
+export type Locale = 'es' | 'en';
+export type { Translation };
+
+const translations: Record<Locale, Translation> = { es, en };
+
+/** Idiomas soportados, en orden. Útil para generar rutas o el toggle. */
+export const locales: Locale[] = ['es', 'en'];
+
+export const defaultLocale: Locale = 'es';
+
+/**
+ * Devuelve el diccionario del idioma pedido. Si llegara un valor imposible,
+ * cae al español en vez de romper el render.
+ */
+export function getTranslation(locale: Locale): Translation {
+	return translations[locale] ?? translations[defaultLocale];
+}
+
+/**
+ * Deduce el idioma a partir de la URL. El inglés vive bajo /en/; todo lo demás
+ * es español. Contempla el `base` del sitio por si algún día deja de ser '/'.
+ */
+export function getLocaleFromUrl(url: URL): Locale {
+	const path = url.pathname.replace(import.meta.env.BASE_URL, '/').replace(/\/{2,}/g, '/');
+	return path === '/en' || path.startsWith('/en/') ? 'en' : 'es';
+}


### PR DESCRIPTION
Cierra **#36** (`P4-1`) y **#37** (`P4-2`). Solo los cimientos — el resto de la Fase 4 (páginas espejo `/en/`, LangToggle, hreflang, sitemap i18n) son issues posteriores y siguen bloqueados por el copy de Fases 2-3.

## Qué hace

**`astro.config.mjs`** — bloque `i18n`: `defaultLocale: 'es'`, `locales: ['es', 'en']`, `prefixDefaultLocale: false` (ES en la raíz, EN bajo `/en/`).

**`src/i18n/`** — `es.ts` (fuente de la verdad), `en.ts`, e `index.ts` con `getTranslation(locale)` y `getLocaleFromUrl(url)`. Solo los strings de UI que existen hoy; la prosa larga y las categorías de Fase 2 se traducen cuando ese contenido esté cerrado.

## Dos decisiones que me aparté del handoff — y por qué

### 1. NO activo el `fallback: { en: 'es' }`

El handoff lo incluye, pero **lo medí**: con `fallback` y cero páginas EN, Astro genera **39 stubs de redirect** `/en/* → /` que se indexarían sin aportar nada. El fallback solo tiene sentido cuando ya existan páginas EN de las que caer, así que va con las páginas espejo (P4-5), no aquí.

Sin él, la config es **inerte** — verificado: build en verde, las 39 páginas quedan **byte-idénticas** a `main` y no se genera ningún `/en/`.

### 2. Corregí un bug de tipado mío

El primer intento (`en: typeof es`) estaba **mal**: como `es` va `as const`, su tipo son los literales españoles, así que exigía que el inglés fuese idéntico al español (`"Home" is not assignable to "Inicio"`). Traducir habría sido imposible.

Corregido con un tipo `Widen` que ensancha los literales a `string` recursivamente: `en.ts` debe tener las **mismas claves** con valores libres. Verificado con `tsc` aislado en tres escenarios:

- Estado correcto → tipa limpio (exit 0)
- Falta una clave → `Property 'languages' is missing` (exit 2)
- Tipo equivocado (número por string) → `Type 'number' is not assignable to type 'string'`

## ⚠️ Ojo con la garantía de tipos

El issue #37 pide "fallar en build si falta una key". **El `pnpm build` de Astro NO comprueba tipos** — usa esbuild, que los borra sin validarlos. Así que la garantía es a nivel de **IDE / `astro check`**, no del build actual.

Para hacerla real habría que añadir `astro check` a CI (instala `@astrojs/check` + `typescript` y añade un paso). No lo metí aquí porque `astro check` valida **todo el proyecto** y podría destapar errores de tipo preexistentes que bloquearían el build — es una decisión aparte con su propio riesgo. Si lo quieres, lo hago en un PR dedicado.

## Verificación

Build en verde, 39 páginas byte-idénticas a `main`, sin rutas nuevas. Tipado demostrado con `tsc`.

Closes #36
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFYBEyKKn8uG2tpGivSywo