### PR TITLE
fix(qa): hallazgos del QA final

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -8,11 +8,11 @@ interface Props {
 	title: string;
 	img: string;
 	img_alt?: string;
-	video?: string;
 	cardSize?: "normal" | "tall" | "wide";
 	aspectRatio?: string;
 	objectPosition?: string;
 	disableLink?: boolean;
+	priority?: boolean;
 }
 
 const {
@@ -20,12 +20,12 @@ const {
 	title,
 	img,
 	img_alt,
-	video,
 	cardSize,
 	id,
 	aspectRatio = "3 / 4",
 	objectPosition = "center",
 	disableLink = false,
+	priority = false,
 } = Astro.props;
 
 const Tag = disableLink ? "div" : "a";
@@ -66,106 +66,20 @@ const href = localizedPath(locale, `/${page}/${id}`);
 			)
 		}
 	</div>
-	{
-		video ? (
-			<div class="video-container">
-				<video
-					src={video}
-					loop
-					muted
-					playsinline
-					preload="none"
-					poster={img}
-				/>
-				<button class="mute-toggle" aria-label="Toggle mute">
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						viewBox="0 0 24 24"
-						fill="currentColor"
-						class="icon-muted"
-					>
-						<path d="M13.5 4.06c0-1.336-1.616-2.005-2.56-1.06l-4.5 4.5H4.508c-1.141 0-2.318.664-2.66 1.905A9.76 9.76 0 001.5 12c0 .898.121 1.768.35 2.595.341 1.24 1.518 1.905 2.659 1.905h1.93l4.5 4.5c.945.945 2.561.276 2.561-1.06V4.06zM17.78 9.22a.75.75 0 10-1.06 1.06L18.44 12l-1.72 1.72a.75.75 0 101.06 1.06l1.72-1.72 1.72 1.72a.75.75 0 101.06-1.06L20.56 12l1.72-1.72a.75.75 0 10-1.06-1.06l-1.72 1.72-1.72-1.72z" />
-					</svg>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						viewBox="0 0 24 24"
-						fill="currentColor"
-						class="icon-unmuted"
-						style="display: none;"
-					>
-						<path d="M13.5 4.06c0-1.336-1.616-2.005-2.56-1.06l-4.5 4.5H4.508c-1.141 0-2.318.664-2.66 1.905A9.76 9.76 0 001.5 12c0 .898.121 1.768.35 2.595.341 1.24 1.518 1.905 2.659 1.905h1.93l4.5 4.5c.945.945 2.561.276 2.561-1.06V4.06zM18.584 5.106a.75.75 0 011.06 0c3.808 3.807 3.808 9.98 0 13.788a.75.75 0 11-1.06-1.06 8.25 8.25 0 000-11.668.75.75 0 010-1.06z" />
-						<path d="M15.932 7.757a.75.75 0 011.061 0 6 6 0 010 8.486.75.75 0 01-1.06-1.061 4.5 4.5 0 000-6.364.75.75 0 010-1.06z" />
-					</svg>
-				</button>
-			</div>
-		) : (
-			<img
-				src={img}
-				alt={img_alt || ""}
-				loading="lazy"
-				decoding="async"
-				width="400"
-				height={
-					400 /
-					(parseFloat(aspectRatio.split("/")[0]) /
-						parseFloat(aspectRatio.split("/")[1] || "1"))
-				}
-			/>
-		)
-	}
+	<img
+		src={img}
+		alt={img_alt || ""}
+		loading={priority ? "eager" : "lazy"}
+		fetchpriority={priority ? "high" : undefined}
+		decoding="async"
+		width="400"
+		height={
+			400 /
+			(parseFloat(aspectRatio.split("/")[0]) /
+				parseFloat(aspectRatio.split("/")[1] || "1"))
+		}
+	/>
 </div>
-
-<script>
-	document.addEventListener("astro:page-load", () => {
-		document.querySelectorAll(".video-container").forEach((container) => {
-			const video = container.querySelector("video");
-			const button = container.querySelector(".mute-toggle");
-			const iconMuted = container.querySelector(
-				".icon-muted",
-			) as HTMLElement;
-			const iconUnmuted = container.querySelector(
-				".icon-unmuted",
-			) as HTMLElement;
-
-			if (video && button && iconMuted && iconUnmuted) {
-				button.addEventListener("click", (e) => {
-					e.preventDefault();
-					e.stopPropagation();
-					video.muted = !video.muted;
-					if (video.muted) {
-						iconMuted.style.display = "block";
-						iconUnmuted.style.display = "none";
-					} else {
-						iconMuted.style.display = "none";
-						iconUnmuted.style.display = "block";
-					}
-				});
-			}
-
-			// Solo se reproduce en viewport para no descargar los 11+ vídeos de un listado a la vez.
-			const prefersReducedMotion = window.matchMedia(
-				"(prefers-reduced-motion: reduce)",
-			).matches;
-
-			if (video && !prefersReducedMotion) {
-				const observer = new IntersectionObserver(
-					(entries) => {
-						for (const entry of entries) {
-							if (entry.isIntersecting) {
-								// play() puede rechazar (p. ej. si el usuario navega antes de que arranque).
-								video.play().catch(() => {});
-							} else {
-								video.pause();
-							}
-						}
-					},
-					{ threshold: 0.25 },
-				);
-				observer.observe(video);
-			}
-		});
-	});
-</script>
 
 <style>
 	.card {
@@ -213,46 +127,12 @@ const href = localizedPath(locale, `/${page}/${id}`);
 		margin-left: 0.5rem;
 	}
 
-	.video-container {
-		position: relative;
-		width: 100%;
-		aspect-ratio: var(--aspect-ratio);
-	}
-
-	img,
-	video {
+	img {
 		width: 100%;
 		height: 100%;
 		aspect-ratio: var(--aspect-ratio);
 		object-fit: cover;
 		object-position: var(--object-position);
-	}
-
-	.mute-toggle {
-		position: absolute;
-		bottom: 1rem;
-		right: 1rem;
-		background: rgba(0, 0, 0, 0.5);
-		border: none;
-		border-radius: 50%;
-		width: 2.5rem;
-		height: 2.5rem;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		color: white;
-		cursor: pointer;
-		transition: background 0.2s;
-		z-index: 20;
-	}
-
-	.mute-toggle:hover {
-		background: rgba(0, 0, 0, 0.8);
-	}
-
-	.mute-toggle svg {
-		width: 1.25rem;
-		height: 1.25rem;
 	}
 
 	@media (min-width: 50em) {

--- a/src/components/ProjectDetail.astro
+++ b/src/components/ProjectDetail.astro
@@ -49,7 +49,7 @@ const descriptionIsSpanish = locale === "en" && !entry.data.descriptionEn;
 					</Hero>
 				</div>
 			</header>
-			<main class="wrapper">
+			<main id="contenido" class="wrapper">
 				<div class="stack gap-10">
 					<CreditsBlock
 						role={entry.data.role}
@@ -63,7 +63,7 @@ const descriptionIsSpanish = locale === "en" && !entry.data.descriptionEn;
 					/>
 					<Grid variant="small">
 						{
-							entry.data.images.map((img) => {
+							entry.data.images.map((img, i) => {
 								const isVideo = /\.(mp4|webm|mov)$/i.test(img);
 								return (
 									<li class="gallery-item">
@@ -84,7 +84,8 @@ const descriptionIsSpanish = locale === "en" && !entry.data.descriptionEn;
 											<img
 												src={img}
 												alt={`${entry.data.title}`}
-												loading="lazy"
+												loading={i === 0 ? "eager" : "lazy"}
+												fetchpriority={i === 0 ? "high" : undefined}
 											/>
 										)}
 									</li>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -70,26 +70,32 @@ export const en: Translation = {
 		newWindowHint: '(opens in a new tab)',
 		portraitAlt: 'Luisa Benítez outdoors, reading a fashion magazine',
 		back: 'Back',
+		skipToContent: 'Skip to content',
 		languageLabel: 'Switch language',
 	},
 	collections: {
 		campaigns: {
+			heading: 'Campaigns',
 			title: 'Campaigns | Luisa Benítez',
 			description: 'Brand campaigns and collaborations Luisa Benítez has worked on',
 		},
 		celebrityEvents: {
+			heading: 'Celebrity & Events',
 			title: 'Celebrity & Events | Luisa Benítez',
 			description: 'Celebrity and event projects Luisa Benítez has worked on',
 		},
 		editorials: {
+			heading: 'Editorials',
 			title: 'Editorials | Luisa Benítez',
 			description: 'Editorials Luisa Benítez has worked on',
 		},
 		films: {
+			heading: 'Film & TV',
 			title: 'Film & TV | Luisa Benítez',
 			description: 'Film and TV projects Luisa Benítez has worked on',
 		},
 		runway: {
+			heading: 'Runway',
 			title: 'Runway | Luisa Benítez',
 			description: 'Runway shows Luisa Benítez has worked on',
 		},

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -75,26 +75,32 @@ export const es = {
 		/** /about y /contact usan la MISMA foto: un solo alt, en un solo sitio. */
 		portraitAlt: 'Luisa Benítez al aire libre, leyendo una revista de moda',
 		back: 'Volver',
+		skipToContent: 'Saltar al contenido',
 		languageLabel: 'Cambiar de idioma',
 	},
 	collections: {
 		campaigns: {
+			heading: 'Campañas',
 			title: 'Campañas | Luisa Benítez',
 			description: 'Campañas y colaboraciones de marca en las que ha trabajado Luisa Benítez',
 		},
 		celebrityEvents: {
+			heading: 'Celebridades y eventos',
 			title: 'Celebridades y eventos | Luisa Benítez',
 			description: 'Celebridades y eventos en los que ha trabajado Luisa Benítez',
 		},
 		editorials: {
+			heading: 'Editoriales',
 			title: 'Editoriales | Luisa Benítez',
 			description: 'Editoriales en las que ha trabajado Luisa Benítez',
 		},
 		films: {
+			heading: 'Cine',
 			title: 'Cine | Luisa Benítez',
 			description: 'Cine en el que ha trabajado Luisa Benítez',
 		},
 		runway: {
+			heading: 'Runway',
 			title: 'Runway | Luisa Benítez',
 			description: 'Desfiles en los que ha trabajado Luisa Benítez',
 		},

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,7 +9,7 @@ import Footer from "../components/Footer.astro";
 import MainHead from "../components/MainHead.astro";
 import Nav from "../components/Nav.astro";
 import SEO from "../components/SEO.astro";
-import { getLocaleFromUrl } from "../i18n";
+import { getLocaleFromUrl, getTranslation } from "../i18n";
 import { alternatePaths, stripLocale } from "../i18n/routing";
 
 interface Props {
@@ -30,6 +30,7 @@ interface Props {
 const { title, description, image, imageAlt, path, hasTranslation = true } =
 	Astro.props;
 const locale = getLocaleFromUrl(Astro.url);
+const t = getTranslation(locale);
 const alternates = hasTranslation
 	? alternatePaths(stripLocale(path ?? Astro.url.pathname))
 	: undefined;
@@ -95,6 +96,7 @@ const alternates = hasTranslation
 		</script>
 	</head>
 	<body>
+		<a class="skip-link" href="#contenido">{t.common.skipToContent}</a>
 		<div class="stack page-shell">
 			<Nav hasTranslation={hasTranslation} />
 			<slot />
@@ -110,6 +112,33 @@ const alternates = hasTranslation
 </html>
 
 <style is:global>
+
+	.skip-link {
+		position: absolute;
+		left: 0.5rem;
+		top: -4rem;
+		z-index: 10000;
+		padding: 0.75rem 1.25rem;
+		border-radius: 0.5rem;
+		background: var(--gray-999);
+		color: var(--gray-0);
+		font-family: var(--font-brand);
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		text-decoration: none;
+		outline: 2px solid var(--gray-0);
+		transition: top 0.15s ease-in-out;
+	}
+
+	.skip-link:focus {
+		top: 0.5rem;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.skip-link {
+			transition: none;
+		}
+	}
 	:root {
 		--gray-0: #090b11;
 		--gray-50: #141925;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,9 +4,26 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout
-	title="Not Found"
-	description="404 Error — this page was not found"
+	title="Página no encontrada | Luisa Benítez"
+	description="La página que buscas no existe o se ha movido."
 	hasTranslation={false}
 >
-	<Hero title="Page Not Found" tagline="Not found" />
+	<main id="contenido" class="wrapper stack gap-8">
+		<Hero title="Página no encontrada" />
+		<p class="lead">
+			La página que buscas no existe o ha cambiado de dirección.
+			<a href="/">Volver al inicio</a>
+		</p>
+		<p class="lead" lang="en">
+			This page doesn’t exist or has moved.
+			<a href="/en/">Back to home</a>
+		</p>
+	</main>
 </BaseLayout>
+
+<style>
+	.lead {
+		font-size: var(--text-lg);
+		text-align: center;
+	}
+</style>

--- a/src/pages/[...lang]/campaigns/index.astro
+++ b/src/pages/[...lang]/campaigns/index.astro
@@ -4,6 +4,7 @@ import { getCollection } from "astro:content";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import Grid from "../../../components/Grid.astro";
 import Card from "../../../components/Card.astro";
+import Hero from "../../../components/Hero.astro";
 import { sortProjects } from "../../../lib/sort-projects";
 import { getTranslation } from "../../../i18n";
 import { localeStaticPaths } from "../../../i18n/routing";
@@ -21,16 +22,18 @@ const campaigns = sortProjects(await getCollection("campaigns"));
     description={t.collections.campaigns.description}
 >
     <div class="stack gap-20 lg:gap-48">
-        <main class="wrapper stack gap-20 lg:gap-48">
+        <header class="wrapper">
+        	<Hero title={t.collections.campaigns.heading} align="start" />
+        </header>
+        <main id="contenido" class="wrapper stack gap-20 lg:gap-48">
             <Grid variant="small">
                 {
-                    campaigns.map((campaign) => {
+                    campaigns.map((campaign, i) => {
                         const { id, data } = campaign;
                         const {
                             title,
                             img,
                             img_alt,
-                            video,
                             cardSize,
                             aspectRatio,
                             objectPosition,
@@ -45,11 +48,11 @@ const campaigns = sortProjects(await getCollection("campaigns"));
                                     title={title}
                                     img={img}
                                     img_alt={img_alt}
-                                    video={video}
                                     cardSize={cardSize}
                                     aspectRatio={aspectRatio}
                                     objectPosition={objectPosition}
                                     disableLink={!hasGallery}
+                                    priority={i === 0}
                                 />
                             </li>
                         );

--- a/src/pages/[...lang]/celebrity-events/index.astro
+++ b/src/pages/[...lang]/celebrity-events/index.astro
@@ -4,6 +4,7 @@ import { getCollection } from "astro:content";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import Grid from "../../../components/Grid.astro";
 import Card from "../../../components/Card.astro";
+import Hero from "../../../components/Hero.astro";
 import { sortProjects } from "../../../lib/sort-projects";
 import { getTranslation } from "../../../i18n";
 import { localeStaticPaths } from "../../../i18n/routing";
@@ -21,10 +22,13 @@ const celebrityEvents = sortProjects(await getCollection("celebrity-events"));
     description={t.collections.celebrityEvents.description}
 >
     <div class="stack gap-20 lg:gap-48">
-        <main class="wrapper stack gap-20 lg:gap-48">
+        <header class="wrapper">
+        	<Hero title={t.collections.celebrityEvents.heading} align="start" />
+        </header>
+        <main id="contenido" class="wrapper stack gap-20 lg:gap-48">
             <Grid variant="small">
                 {
-                    celebrityEvents.map((celebrity) => (
+                    celebrityEvents.map((celebrity, i) => (
                         <li>
                             <Card
                                 id={celebrity.id}
@@ -35,6 +39,7 @@ const celebrityEvents = sortProjects(await getCollection("celebrity-events"));
                                 cardSize={celebrity.data.cardSize}
                                 aspectRatio={celebrity.data.aspectRatio}
                                 objectPosition={celebrity.data.objectPosition}
+                                priority={i === 0}
                             />
                         </li>
                     ))

--- a/src/pages/[...lang]/contact.astro
+++ b/src/pages/[...lang]/contact.astro
@@ -50,7 +50,7 @@ const details: { label: string; value: string }[] = [
 	title={t.contact.pageTitle}
 	description={t.contact.metaDescription}
 >
-	<main class="contact">
+	<main id="contenido" class="contact">
 		<div class="portrait">
 			<Image
 				src={portrait}

--- a/src/pages/[...lang]/editorials/index.astro
+++ b/src/pages/[...lang]/editorials/index.astro
@@ -4,6 +4,7 @@ import { getCollection } from "astro:content";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import Grid from "../../../components/Grid.astro";
 import Card from "../../../components/Card.astro";
+import Hero from "../../../components/Hero.astro";
 import { sortProjects } from "../../../lib/sort-projects";
 import { getTranslation } from "../../../i18n";
 import { localeStaticPaths } from "../../../i18n/routing";
@@ -21,10 +22,13 @@ const editorials = sortProjects(await getCollection("editorials"));
     description={t.collections.editorials.description}
 >
     <div class="stack gap-20 lg:gap-48">
-        <main class="wrapper stack gap-20 lg:gap-48">
+        <header class="wrapper">
+        	<Hero title={t.collections.editorials.heading} align="start" />
+        </header>
+        <main id="contenido" class="wrapper stack gap-20 lg:gap-48">
             <Grid variant="small">
                 {
-                    editorials.map((editorial) => {
+                    editorials.map((editorial, i) => {
                         const { id, data } = editorial;
                         const {
                             title,
@@ -46,6 +50,7 @@ const editorials = sortProjects(await getCollection("editorials"));
                                     cardSize={cardSize}
                                     aspectRatio={aspectRatio}
                                     objectPosition={objectPosition}
+                                    priority={i === 0}
                                 />
                             </li>
                         );

--- a/src/pages/[...lang]/films/index.astro
+++ b/src/pages/[...lang]/films/index.astro
@@ -4,6 +4,7 @@ import { getCollection } from "astro:content";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import Grid from "../../../components/Grid.astro";
 import Card from "../../../components/Card.astro";
+import Hero from "../../../components/Hero.astro";
 import { sortProjects } from "../../../lib/sort-projects";
 import { getTranslation } from "../../../i18n";
 import { localeStaticPaths } from "../../../i18n/routing";
@@ -21,10 +22,13 @@ const films = sortProjects(await getCollection("films"));
     description={t.collections.films.description}
 >
     <div class="stack gap-20 lg:gap-48">
-        <main class="wrapper stack gap-20 lg:gap-48">
+        <header class="wrapper">
+        	<Hero title={t.collections.films.heading} align="start" />
+        </header>
+        <main id="contenido" class="wrapper stack gap-20 lg:gap-48">
             <Grid variant="small">
                 {
-                    films.map((film) => (
+                    films.map((film, i) => (
                         <li>
                             <Card
                                 id={film.id}
@@ -35,6 +39,7 @@ const films = sortProjects(await getCollection("films"));
                                 cardSize={film.data.cardSize}
                                 aspectRatio={film.data.aspectRatio}
                                 objectPosition={film.data.objectPosition}
+                                priority={i === 0}
                             />
                         </li>
                     ))

--- a/src/pages/[...lang]/index.astro
+++ b/src/pages/[...lang]/index.astro
@@ -87,15 +87,6 @@ if (profile.availableForTravel) {
 	description={t.meta.siteDescription}
 >
 	<div class="stack gap-20">
-		<!--
-			El <h1> es el nombre, no "Sobre Mí"; nada de texto superpuesto ni velo (ver heroTiles arriba).
-
-			La sección lleva class .wrapper (mismo max-width/gutter que el resto
-			de la página) para que .hero-grid comparta borde izquierdo con las
-			demás secciones, en vez de sangrar a left: 0. El panel de texto
-			(eyebrow/h1/tagline/instagram) sigue sin alinearse a esa vertical a
-			propósito: vive a la derecha de la rejilla.
-		-->
 		<section class="hero wrapper">
 			<div class="hero-grid">
 				{
@@ -132,7 +123,7 @@ if (profile.availableForTravel) {
 			</div>
 		</section>
 
-		<main class="wrapper stack gap-20">
+		<main id="contenido" class="wrapper stack gap-20">
 			<section class="section with-background with-cta">
 				<header class="section-header stack gap-2 lg:gap-4">
 					<h2>{t.home.featuredWorkTitle}</h2>
@@ -147,7 +138,6 @@ if (profile.availableForTravel) {
 									title,
 									img,
 									img_alt,
-									video,
 									cardSize,
 									aspectRatio,
 									objectPosition,
@@ -162,7 +152,6 @@ if (profile.availableForTravel) {
 											title={title}
 											img={img}
 											img_alt={img_alt}
-											video={video}
 											cardSize={cardSize}
 											aspectRatio={aspectRatio}
 											objectPosition={objectPosition}
@@ -175,11 +164,6 @@ if (profile.availableForTravel) {
 					</Grid>
 				</div>
 			</section>
-
-			<!--
-				Sin retrato: el actual no da para acompañar la bio y su sitio
-				natural es /contact. Todo el texto sale de t.about y t.profile.
-			-->
 			<section id="sobre-mi" class="about">
 				<div class="about-grid">
 					<div class="about-content">

--- a/src/pages/[...lang]/runway/index.astro
+++ b/src/pages/[...lang]/runway/index.astro
@@ -4,6 +4,7 @@ import { getCollection } from "astro:content";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import Grid from "../../../components/Grid.astro";
 import Card from "../../../components/Card.astro";
+import Hero from "../../../components/Hero.astro";
 import { sortProjects } from "../../../lib/sort-projects";
 import { getTranslation } from "../../../i18n";
 import { localeStaticPaths } from "../../../i18n/routing";
@@ -21,16 +22,18 @@ const runway = sortProjects(await getCollection("runway"));
     description={t.collections.runway.description}
 >
     <div class="stack gap-20 lg:gap-48">
-        <main class="wrapper stack gap-20 lg:gap-48">
+        <header class="wrapper">
+        	<Hero title={t.collections.runway.heading} align="start" />
+        </header>
+        <main id="contenido" class="wrapper stack gap-20 lg:gap-48">
             <Grid variant="small">
                 {
-                    runway.map((campaign) => {
+                    runway.map((campaign, i) => {
                         const { id, data } = campaign;
                         const {
                             title,
                             img,
                             img_alt,
-                            video,
                             cardSize,
                             aspectRatio,
                             objectPosition,
@@ -45,11 +48,11 @@ const runway = sortProjects(await getCollection("runway"));
                                     title={title}
                                     img={img}
                                     img_alt={img_alt}
-                                    video={video}
                                     cardSize={cardSize}
                                     aspectRatio={aspectRatio}
                                     objectPosition={objectPosition}
                                     disableLink={!hasGallery}
+                                    priority={i === 0}
                                 />
                             </li>
                         );


### PR DESCRIPTION
Arregla lo que encontró el QA final (#49). Todo medido sobre el build de producción con red móvil limitada (1,6 Mbps, 150 ms), que es la que usa Lighthouse.

## El hallazgo importante

Recorrer `/campaigns/` en el móvil descargaba **25,5 MB**. Las tarjetas reproducían el vídeo al entrar en pantalla y en esa categoría hay nueve, de entre 4 y 8 MB.

| | Antes | Ahora |
|---|---|---|
| `/campaigns/` | **25,5 MB** | **0,9 MB** |
| `/runway/` | 3,7 MB | 0,7 MB |

Los listados muestran ahora el póster, que ya existía, y el vídeo se reproduce en la ficha del proyecto, donde el visitante ya ha decidido verlo. De paso desaparece el `IntersectionObserver` de las tarjetas.

## Accesibilidad

**Las diez páginas de categoría no tenían ningún encabezado.** `/campaigns/` iba del menú directo a la cuadrícula: ni `<h1>` ni nada. Sin punto de anclaje para un lector de pantalla y sin encabezado para Google.

**No había enlace de salto** (WCAG 2.4.1, nivel A). Son siete enlaces de menú repetidos en cada página. Ahora es el primer tabulador, invisible hasta recibir el foco.

**El 404 estaba entero en inglés** en un sitio cuyo idioma por defecto es el español, sin `<main>` y con una raya larga. Ahora es bilingüe, con enlace de vuelta en cada idioma.

## Menor

La primera imagen de cada listado y de cada galería deja de cargarse en diferido: era precisamente la que define el LCP. Y fuera dos comentarios HTML internos que se publicaban en la home.

## Lo que el QA da por bueno

| | |
|---|---|
| Desbordes horizontales | **0** en 12 páginas × 3 anchos × 2 temas |
| Contraste | mínimo **13,15:1** (se exige 4,5:1) |
| Foco de teclado | visible en toda la navegación |
| Imágenes sin `alt` | **0** |
| CLS | **≤ 0,061** (objetivo < 0,1) |
| Título, descripción, canonical, `og:image`, `hreflang` | completos en las 87 páginas reales |
| Texto de relleno | ninguno |

## Lo que NO queda resuelto, y por qué

**El LCP sigue por encima del objetivo en listados y fichas**: 4,2 s en `/campaigns/`, 3,2 s y 4,7 s en fichas, frente a los 2,5 s que pide la issue. La home va a 0,6 s.

No es un defecto tapable: el elemento LCP es una sola foto de 307 KB, y a 1,6 Mbps eso son varios segundos. Comprobado que **no sobra resolución** — el ancho máximo que necesita una tarjeta es **1436 px**, en tablet a DPR2 — y que recomprimir solo da un 18% a costa de calidad. Cerrar esa brecha exige imágenes responsivas (`srcset`/`sizes`), que es el P3 que revertimos por servirlas al 33% de la resolución necesaria. Merece hacerse bien y con medición por punto de ruptura, no de propina en este PR.

**Cinco proyectos tienen el material de origen por debajo de lo que pide la tarjeta** en pantallas densas: los vídeos son de 608×1080 y el de Vogue Spain, de 360×640, cuando a 390 px DPR3 harían falta 1020. Esto **ya pasaba antes** de este PR —los vídeos eran igual de cortos— pero no se medía porque la comprobación solo miraba elementos `<img>`. No se arregla procesando: hace falta material mejor de Luisa.

## Límites de este QA

Solo **Chromium**: Firefox y WebKit no están instalados en este entorno, y Safari importa porque el público es de iPhone. Todo headless, sin lector de pantalla real. La #49 no debería cerrarse sin una pasada manual en un móvil de verdad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQ3fpT2Ck2fq8HqqJ5vtr
