### PR TITLE
feat(contacto): correo propio del dominio

### DIFF
--- a/src/data/profile.ts
+++ b/src/data/profile.ts
@@ -18,8 +18,7 @@ export const profile = {
 	baseCity: 'A Coruña',
 	availableForTravel: true,
 
-	/** TODO(#17): cambiar a hello@luisabenitez.es cuando H-7 (#14) resuelva el backend de email. */
-	email: 'luisafernandabenitezariza@gmail.com',
+	email: 'luisa@luisabenitez.es',
 
 	instagram: {
 		handle: '@luisabeniteza',


### PR DESCRIPTION
Cierra #17.

`luisa@luisabenitez.es` en lugar del Gmail personal. El dominio **no podía recibir correo** hasta hoy: no tenía ningún registro MX. Se resuelve con Cloudflare Email Routing, que reenvía al Gmail de Luisa. Probado con un envío real.

## Por qué el nombre propio

Se descartaron `hello@` y `contact@`. A un estilista le escribe una persona, no una empresa: un buzón genérico sugiere un equipo o un formulario detrás, y en un servicio personal eso resta. Además `hello@` es inglés en un sitio cuyo idioma por defecto es el español, y un nombre propio funciona igual en los dos.

## Verificado

- Cero rastro del Gmail personal en las 115 páginas del build.
- `/contact/` emite `mailto:luisa@luisabenitez.es`.
- MX y SPF publicados en la zona: `route1/2/3.mx.cloudflare.net`, `v=spf1 include:_spf.mx.cloudflare.net ~all`.
- `pnpm check:links` en verde y el conjunto de URLs españolas sin cambios.

## Lo que esto NO resuelve

**Email Routing solo recibe.** Cuando Luisa responda, el remitente seguirá siendo su Gmail. Si el portfolio genera conversación con una marca, remitente y web dirán cosas distintas justo en el momento que importa. Resolverlo pide un SMTP externo o Google Workspace, y es la decisión que sigue abierta en #14.

**Conviene que el CV lleve la misma dirección** (#10). Si el PDF dice el Gmail y la web dice otra cosa, quien reciba ambos no sabrá cuál usar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQ3fpT2Ck2fq8HqqJ5vtr