### PR TITLE
feat(nav): cabecera que se esconde al bajar en móvil

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -213,10 +213,35 @@ const activeLink = textLinks.find((link) => isCurrentPage(link.href));
 	customElements.define('menu-button', MenuButton);
 </script>
 
+<script>
+	document.addEventListener("astro:page-load", () => {
+		const nav = document.querySelector<HTMLElement>("nav");
+		const menu = document.getElementById("menu-content");
+		if (!nav) return;
+
+		let ultimo = window.scrollY;
+
+		function alDesplazar() {
+			const y = window.scrollY;
+			const bajando = y > ultimo;
+			// Con el menú desplegado la cabecera no se esconde: sería tirar de la
+			// alfombra a quien acaba de abrirlo.
+			const menuAbierto = menu ? !menu.hidden : false;
+			if (y < nav!.offsetHeight || menuAbierto) nav!.removeAttribute("data-oculta");
+			else if (bajando && y - ultimo > 4) nav!.setAttribute("data-oculta", "");
+			else if (!bajando && ultimo - y > 4) nav!.removeAttribute("data-oculta");
+			ultimo = y;
+		}
+
+		window.addEventListener("scroll", alDesplazar, { passive: true });
+	});
+</script>
+
 <style>
 	nav {
 		z-index: 9999;
 		position: relative;
+		background-color: var(--gray-999);
 		font-weight: 500;
 		margin-bottom: 2rem;
 	}
@@ -529,6 +554,24 @@ const activeLink = textLinks.find((link) => isCurrentPage(link.href));
 	@media (forced-colors: active) {
 		.link[aria-current='page'] {
 			color: SelectedItem;
+		}
+	}
+
+	@media (max-width: 87.99em) {
+		nav {
+			position: sticky;
+			top: 0;
+			transition: transform 0.25s ease-in-out;
+		}
+
+		nav[data-oculta] {
+			transform: translateY(-100%);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		nav {
+			transition: none;
 		}
 	}
 </style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -291,7 +291,9 @@ const alternates = hasTranslation
 	html,
 	body {
 		min-height: 100%;
-		overflow-x: hidden;
+		/* `clip` y no `hidden`: hidden convierte el elemento en contenedor de
+		   scroll y rompe el `position: sticky` de la cabecera. */
+		overflow-x: clip;
 	}
 
 	body {


### PR DESCRIPTION
La cabecera **mide 140 px**. Medido en el build:

| | Ocupa |
|---|---|
| iPhone normal (390×844) | **17%** del alto |
| iPhone con las barras de Safari (390×664) | **21%** |

Fijarla siempre habría sido regalar una quinta parte de la pantalla de forma permanente, en un sitio cuyo contenido son fotos verticales. Así que se esconde al bajar y reaparece al subir: bajar es «quiero ver», subir es «quiero navegar».

**En escritorio no cambia nada**, se sigue yendo con el scroll.

## El detalle que casi lo rompe

El sitio tenía `overflow-x: hidden` en `html, body`. Eso **convierte el elemento en contenedor de scroll y anula el `position: sticky`** de cualquier descendiente — es la razón por la que la primera versión medía `position: relative` pese a la regla.

Cambiado a `overflow-x: clip`, que recorta igual **sin** crear el contenedor. Verificado que la protección contra desbordes sigue haciendo su trabajo: **0 elementos desbordan** a 390 px.

(La primera versión tenía además la regla al principio del bloque de estilos, donde la pisaba la regla base que va después. Movida al final.)

## Dos decisiones

- **Con el menú desplegado no se esconde.** Sería tirar de la alfombra a quien acaba de abrirlo.
- **En los primeros 140 px de scroll siempre está visible**, para que no parpadee al empezar la página.

Respeta `prefers-reduced-motion`: sin transición.

## Verificado

```
móvil (390px)       arriba: top 0px sticky visible
                    bajando: top -140px sticky OCULTA
                    subiendo: top 0px sticky visible

escritorio (1440px) sin cambios, position: relative
```

115 páginas, `check:links` en verde, cero desbordes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQ3fpT2Ck2fq8HqqJ5vtr