### PR TITLE
fix(visor): sonido, barra de reproducción, fondo negro y huella en assets

### DIFF
--- a/scripts/verify-viewer.mjs
+++ b/scripts/verify-viewer.mjs
@@ -450,14 +450,13 @@ try {
 	];
 	for (const shot of shotPlan) await captureShot(shot.ctx, shot);
 
+	// Antes se exigía que el fondo difiriera entre temas, como prueba de que el
+	// tema se había aplicado. Ya no vale: el visor es negro a propósito en los dos,
+	// porque en claro el blanco rodeaba la foto. Que el tema se aplica lo garantiza
+	// el abortAssert de captureShot, que es una comprobación más fuerte.
 	check(
-		bg["viewer-390-light-photo.png"] !== bg["viewer-390-dark-photo.png"],
-		"390px: el fondo del visor difiere entre tema claro y oscuro (no son duplicados)",
-		bg,
-	);
-	check(
-		bg["viewer-1440-light-photo.png"] !== bg["viewer-1440-dark-photo.png"],
-		"1440px: el fondo del visor difiere entre tema claro y oscuro (no son duplicados)",
+		Object.values(bg).every((c) => c === "rgb(0, 0, 0)"),
+		"el fondo del visor es negro en los dos temas y en las dos anchuras",
 		bg,
 	);
 	measurements.screenshotBackgrounds = bg;

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -2,6 +2,7 @@
 import { getLocaleFromUrl } from "../i18n";
 import { localizedPath } from "../i18n/routing";
 import { CARD_SIZES, cardSrcset } from "../lib/card-srcset";
+import { conHuella } from "../lib/asset-version";
 
 interface Props {
 	id: string;
@@ -69,7 +70,7 @@ const href = localizedPath(locale, `/${page}/${id}`);
 		}
 	</div>
 	<img
-		src={img}
+		src={conHuella(img)}
 		srcset={srcset}
 		sizes={srcset ? CARD_SIZES : undefined}
 		alt={img_alt || ""}

--- a/src/components/GalleryViewer.astro
+++ b/src/components/GalleryViewer.astro
@@ -1,4 +1,5 @@
 ---
+import { conHuella } from "../lib/asset-version";
 import Icon from "./Icon.astro";
 import { getMediaSize, posterPath } from "../lib/mediaDimensions";
 import { getTranslation, type Locale } from "../i18n";
@@ -34,8 +35,8 @@ const media = await Promise.all(
 				<li class="viewer-slide">
 					{m.isVideo ? (
 						<video
-							src={`${m.src}#t=1`}
-							poster={posterPath(m.src)}
+							src={`${conHuella(m.src)}#t=1`}
+							poster={conHuella(posterPath(m.src))}
 							aria-label={fill(t.viewer.altVideo, i)}
 							width={m.size?.width}
 							height={m.size?.height}
@@ -57,7 +58,7 @@ const media = await Promise.all(
 						</button>
 					) : (
 						<img
-							src={m.src}
+							src={conHuella(m.src)}
 							alt={fill(t.viewer.altImage, i)}
 							loading="lazy"
 							width={m.size?.width}

--- a/src/components/GalleryViewer.astro
+++ b/src/components/GalleryViewer.astro
@@ -68,6 +68,7 @@ const media = await Promise.all(
 			))
 		}
 	</ul>
+	<div class="viewer-progreso" data-viewer-progreso hidden><span></span></div>
 	<div class="viewer-bar">
 		<p class="viewer-counter" aria-hidden="true"></p>
 		<p class="viewer-announcer sr-only" role="status"></p>
@@ -95,8 +96,10 @@ const media = await Promise.all(
 		width: 100vw;
 		height: 100vh;
 		height: 100dvh;
-		background: var(--gray-999);
-		color: var(--gray-0);
+		/* Siempre oscuro, no el color del tema: en claro el blanco rodeaba la foto
+		   y competía con ella. Es lo que hace cualquier visor a pantalla completa. */
+		background: #000;
+		color: #fff;
 		overflow: hidden;
 		/* En los DOS ejes y en el diálogo, no sólo en el carril: un arrastre vertical
 		   se encadena al fondo en iOS si sólo se contiene el eje x. */
@@ -216,6 +219,50 @@ const media = await Promise.all(
 	html.viewer-open {
 		overflow: hidden;
 	}
+
+	.viewer-sound {
+		position: absolute;
+		right: 1rem;
+		bottom: 5rem;
+		display: grid;
+		place-items: center;
+		width: 44px;
+		height: 44px;
+		border: 0;
+		border-radius: 999rem;
+		background: rgb(0 0 0 / 0.55);
+		color: #fff;
+		cursor: pointer;
+	}
+
+	.viewer-sound svg {
+		width: 22px;
+		height: 22px;
+	}
+
+	.viewer-sound[hidden] {
+		display: none;
+	}
+
+	.viewer-progreso {
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 4rem;
+		height: 3px;
+		background: rgb(255 255 255 / 0.25);
+	}
+
+	.viewer-progreso[hidden] {
+		display: none;
+	}
+
+	.viewer-progreso span {
+		display: block;
+		height: 100%;
+		width: 0;
+		background: #fff;
+	}
 </style>
 
 <script>
@@ -265,6 +312,10 @@ const media = await Promise.all(
 		const movil = window.matchMedia("(max-width: 49.99em)");
 		const sonido = dialog.querySelector<HTMLButtonElement>("[data-viewer-sound]");
 
+		function refrescarProgresoSiExiste() {
+			try { refrescarProgreso(); } catch { /* aún no definida en el primer aplicarModo() */ }
+		}
+
 		function aplicarModo() {
 			const videos = dialog.querySelectorAll<HTMLVideoElement>("[data-viewer-video]");
 			videos.forEach((v) => {
@@ -272,6 +323,7 @@ const media = await Promise.all(
 				else v.setAttribute("controls", "");
 			});
 			if (sonido) sonido.hidden = !movil.matches || !videos.length;
+			refrescarProgresoSiExiste();
 			dialog.classList.toggle("movil", movil.matches);
 		}
 		aplicarModo();
@@ -288,6 +340,7 @@ const media = await Promise.all(
 			if (!movil.matches) return;
 			if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
 			videoActivo()?.play().catch(() => {});
+			refrescarProgresoSiExiste();
 		}
 
 		rail.addEventListener("click", (e) => {
@@ -296,6 +349,26 @@ const media = await Promise.all(
 			const v = videoActivo();
 			if (!v) return;
 			v.paused ? v.play().catch(() => {}) : v.pause();
+		});
+
+		const progreso = dialog.querySelector<HTMLElement>("[data-viewer-progreso]");
+		const relleno = progreso?.querySelector<HTMLElement>("span");
+
+		function refrescarProgreso() {
+			const v = videoActivo();
+			if (!progreso || !relleno) return;
+			progreso.hidden = !movil.matches || !v;
+			if (!v || !v.duration) return;
+			relleno.style.width = `${(v.currentTime / v.duration) * 100}%`;
+		}
+
+		dialog.addEventListener("timeupdate", refrescarProgreso, true);
+
+		progreso?.addEventListener("click", (e) => {
+			const v = videoActivo();
+			if (!v || !v.duration) return;
+			const r = progreso.getBoundingClientRect();
+			v.currentTime = ((e.clientX - r.left) / r.width) * v.duration;
 		});
 
 		sonido?.addEventListener("click", () => {

--- a/src/components/ProjectDetail.astro
+++ b/src/components/ProjectDetail.astro
@@ -1,4 +1,5 @@
 ---
+import { conHuella } from "../lib/asset-version";
 import type { CollectionEntry } from "astro:content";
 
 import ContactCTA from "./ContactCTA.astro";
@@ -43,7 +44,7 @@ const fill = (tpl: string, i: number) =>
 <BaseLayout
 	title={`${entry.data.title} | Luisa Benítez`}
 	description={description ?? entry.data.title}
-	image={`/assets/og/${collection}/${entry.id}.jpg`}
+	image={conHuella(`/assets/og/${collection}/${entry.id}.jpg`)}
 	imageAlt={entry.data.img_alt ?? entry.data.title}
 >
 	<div class="stack gap-20">
@@ -87,8 +88,8 @@ const fill = (tpl: string, i: number) =>
 										>
 											{isVideo ? (
 												<video
-													src={`${img}#t=1`}
-													poster={posterPath(img)}
+													src={`${conHuella(img)}#t=1`}
+													poster={conHuella(posterPath(img))}
 													aria-label={fill(t.viewer.altVideo, i)}
 													loop
 													muted
@@ -97,7 +98,7 @@ const fill = (tpl: string, i: number) =>
 												/>
 											) : (
 												<img
-													src={img}
+													src={conHuella(img)}
 													alt={fill(t.viewer.altImage, i)}
 													loading={i === 0 ? "eager" : "lazy"}
 													fetchpriority={i === 0 ? "high" : undefined}

--- a/src/lib/asset-version.ts
+++ b/src/lib/asset-version.ts
@@ -1,0 +1,24 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const cache = new Map<string, string>();
+
+// Los ficheros de /assets/ tienen nombre fijo (index.webp, video-1.mp4), así que
+// al cambiar una foto la URL no cambia y la caché sigue sirviendo la vieja. La
+// huella del contenido convierte cada cambio en una URL nueva, como ya hace Astro
+// con /_astro/. Sin esto hay que purgar Cloudflare a mano cada vez.
+export function conHuella(ruta: string): string {
+	if (!ruta.startsWith('/assets/')) return ruta;
+	if (cache.has(ruta)) return cache.get(ruta)!;
+
+	const fichero = join('public', ruta);
+	let valor = ruta;
+	if (existsSync(fichero)) {
+		const huella = createHash('sha1').update(readFileSync(fichero)).digest('hex').slice(0, 8);
+		valor = `${ruta}?v=${huella}`;
+	}
+
+	cache.set(ruta, valor);
+	return valor;
+}

--- a/src/lib/card-srcset.ts
+++ b/src/lib/card-srcset.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import sharp from 'sharp';
+import { conHuella } from './asset-version';
 
 // Medido en el build, no estimado: la tarjeta ocupa el 94% de la pantalla hasta
 // 800px, el 27% por encima, y se topa en 382px a partir de ~1400.
@@ -24,8 +25,8 @@ export async function cardSrcset(img: string): Promise<string | undefined> {
 			// El original entra en la lista: cuando la fuente es más estrecha que
 			// la mayor variante posible, es la única candidata que llega.
 			const natural = (await sharp(join('public', img)).metadata()).width ?? 0;
-			const entradas = anchos.map((w) => `${dir}/srcset/${w}.webp ${w}w`);
-			if (natural && !anchos.includes(natural)) entradas.push(`${img} ${natural}w`);
+			const entradas = anchos.map((w) => `${conHuella(`${dir}/srcset/${w}.webp`)} ${w}w`);
+			if (natural && !anchos.includes(natural)) entradas.push(`${conHuella(img)} ${natural}w`);
 			valor = entradas.join(', ');
 		}
 	}


### PR DESCRIPTION
Estos tres commits se quedaron fuera del #75: los empujé después de que lo mergearas. Es justo lo que arregla los dos fallos que David encontró probando en el iPhone, más el problema de caché que salió con las portadas.

## Los dos fallos del visor

**El botón de sonido medía 0×0.** Lo añadí al marcado y **nunca le puse estilos**, así que existía y era inalcanzable. Por eso no se podía activar el sonido. Ahora 44×44.

**No había barra de reproducción.** Al quitar los mandos nativos de iOS se perdió, y sin ella no hay forma de saber por dónde va el vídeo. Se añade una, tocable para saltar.

**El «borde blanco» no era un borde: era el fondo.** El visor usaba el color del tema, así que en claro valía blanco y rodeaba la foto compitiendo con ella. Ahora es negro en los dos temas, como cualquier visor a pantalla completa.

## La huella en los assets

Las tres portadas nuevas no se veían en producción. No era un fallo del despliegue:

```
cf-cache-status: HIT     age: 36331s
servido: 29854 bytes  ←  la portada vieja
en repo: 23946 bytes  ←  la nueva
```

Los ficheros de `/assets/` tienen **nombre fijo**, así que al cambiar una foto la URL no cambiaba y Cloudflare seguía sirviendo la anterior durante un mes — el efecto secundario de las reglas de caché, avisado al ponerlas pero olvidado a la primera ocasión.

Ahora la URL lleva `?v=` con un hash del contenido:

```
/assets/publicity/alaniz-maria-pombo/index.webp?v=e7034868
```

Al cambiar el fichero cambia la URL y el navegador la pide solo. Es lo mismo que Astro hace con `/_astro/`, y por eso esos sí pueden cachearse un año sin riesgo. **Se acabó tener que acordarse de purgar.**

## Una aserción que se adaptó, no se debilitó

Al poner el visor en negro, `verify:viewer` empezó a fallar: exigía que el fondo difiriera entre temas, como prueba de que el tema se había aplicado. Esa premisa dejó de ser cierta a propósito.

No se borró la comprobación: ahora exige negro en las cuatro variantes. La garantía de que el tema se aplica ya la daba el `abortAssert` de `captureShot`, que es más fuerte.

## Verificado

- `pnpm verify:viewer` → **código 0**, 100 aserciones.
- **Cero URLs de `/assets/` sin huella** en las 115 páginas.
- 87 mediciones de resolución, **cero elecciones incorrectas** — se comprobó que la cadena de consulta no rompiera el `srcset`.
- `check:links` en verde.

## Nota operativa

Hace falta **una purga más** en Cloudflare para las páginas ya publicadas, que llevan las URLs viejas. A partir del siguiente despliegue ya no.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQ3fpT2Ck2fq8HqqJ5vtr