### PR TITLE
fix(visor): la barra se arrastra y los controles solo salen en vídeo

### DIFF
--- a/src/components/GalleryViewer.astro
+++ b/src/components/GalleryViewer.astro
@@ -245,11 +245,28 @@ const media = await Promise.all(
 		display: none;
 	}
 
+	/* 3px es intocable con el dedo y el gesto se lo quedaba el carril. La zona
+	   sensible mide 24px y la línea visible sigue siendo fina.
+	   `touch-action: none` SOLO aquí: es una franja de control, no el medio, así
+	   que no afecta al pinch-zoom de la foto. */
 	.viewer-progreso {
 		position: absolute;
 		left: 0;
 		right: 0;
-		bottom: 4rem;
+		bottom: 3.4rem;
+		height: 24px;
+		display: flex;
+		align-items: center;
+		padding-inline: 1rem;
+		touch-action: none;
+		cursor: pointer;
+	}
+
+	.viewer-progreso::before {
+		content: "";
+		position: absolute;
+		left: 1rem;
+		right: 1rem;
 		height: 3px;
 		background: rgb(255 255 255 / 0.25);
 	}
@@ -259,8 +276,9 @@ const media = await Promise.all(
 	}
 
 	.viewer-progreso span {
+		position: relative;
 		display: block;
-		height: 100%;
+		height: 3px;
 		width: 0;
 		background: #fff;
 	}
@@ -323,7 +341,6 @@ const media = await Promise.all(
 				if (movil.matches) v.removeAttribute("controls");
 				else v.setAttribute("controls", "");
 			});
-			if (sonido) sonido.hidden = !movil.matches || !videos.length;
 			refrescarProgresoSiExiste();
 			dialog.classList.toggle("movil", movil.matches);
 		}
@@ -357,6 +374,9 @@ const media = await Promise.all(
 
 		function refrescarProgreso() {
 			const v = videoActivo();
+			// Dependen de la diapositiva activa, no de que el proyecto tenga vídeos:
+			// si no, salían también sobre las fotos.
+			if (sonido) sonido.hidden = !movil.matches || !v;
 			if (!progreso || !relleno) return;
 			progreso.hidden = !movil.matches || !v;
 			if (!v || !v.duration) return;
@@ -365,12 +385,26 @@ const media = await Promise.all(
 
 		dialog.addEventListener("timeupdate", refrescarProgreso, true);
 
-		progreso?.addEventListener("click", (e) => {
+		function saltarA(clientX: number) {
 			const v = videoActivo();
-			if (!v || !v.duration) return;
+			if (!v || !v.duration || !progreso) return;
 			const r = progreso.getBoundingClientRect();
-			v.currentTime = ((e.clientX - r.left) / r.width) * v.duration;
+			const p = Math.min(1, Math.max(0, (clientX - r.left) / r.width));
+			v.currentTime = p * v.duration;
+			refrescarProgreso();
+		}
+
+		let arrastrandoBarra = false;
+		progreso?.addEventListener("pointerdown", (e) => {
+			arrastrandoBarra = true;
+			progreso.setPointerCapture(e.pointerId);
+			saltarA(e.clientX);
 		});
+		progreso?.addEventListener("pointermove", (e) => {
+			if (arrastrandoBarra) saltarA(e.clientX);
+		});
+		progreso?.addEventListener("pointerup", () => { arrastrandoBarra = false; });
+		progreso?.addEventListener("pointercancel", () => { arrastrandoBarra = false; });
 
 		sonido?.addEventListener("click", () => {
 			const v = videoActivo();


### PR DESCRIPTION
Los dos fallos que David encontró grabando la pantalla en el iPhone.

## La barra de reproducción no se podía usar

Dos causas a la vez:

**Medía 3 px de alto.** Es un objetivo táctil imposible: el dedo cae fuera y el gesto se lo queda el carril, que desliza en horizontal — de ahí que intentar adelantar el vídeo cambiara de contenido. La zona sensible pasa a **24 px**, con la línea fina visible dentro.

**Solo escuchaba el toque, no el arrastre.** Ahora usa captura de puntero, así que se puede recorrer el vídeo sin soltar el dedo.

## El control de sonido salía en las fotos

Se mostraba si el **proyecto** tenía algún vídeo, no si la **diapositiva activa** lo era. Ahora tanto el botón de sonido como la barra dependen de la diapositiva.

```
diapositiva 1 (foto)   sonido oculto    barra oculta
diapositiva 7 (vídeo)  sonido VISIBLE   barra VISIBLE, 24px
```

## Una prohibición que se respeta con matiz

`touch-action: none` va **solo en la franja de control**. El visor lo tiene prohibido en general porque mataría el pinch-zoom de las fotos, que es la única ampliación disponible para baja visión (WCAG 1.4.4 AA). Una barra de 24 px no es el medio, así que el zoom sobre la imagen sigue intacto. Queda comentado en el CSS para que nadie lo lea como una excepción arbitraria.

## Verificado

`pnpm verify:viewer` en código 0 con sus 100 aserciones, y comprobado por medición que el sonido y la barra aparecen y desaparecen según el tipo de diapositiva.

Lo que **no** está verificado, como siempre con este visor: si el arrastre se siente bien con el dedo. Eso solo lo dice un iPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQ3fpT2Ck2fq8HqqJ5vtr
