### PR TITLE
fix(visor): el toque llega a la barra y el icono de sonido cambia

### DIFF
--- a/src/components/GalleryViewer.astro
+++ b/src/components/GalleryViewer.astro
@@ -260,6 +260,9 @@ const media = await Promise.all(
 		padding-inline: 1rem;
 		touch-action: none;
 		cursor: pointer;
+		/* Sin esto la barra de controles, que se pinta después, se queda el toque:
+		   medido con elementFromPoint sobre el centro de la franja. */
+		z-index: 1;
 	}
 
 	.viewer-progreso::before {
@@ -410,8 +413,12 @@ const media = await Promise.all(
 			const v = videoActivo();
 			if (!v) return;
 			v.muted = !v.muted;
-			sonido.querySelector<HTMLElement>('[data-icono="mudo"]')!.hidden = !v.muted;
-			sonido.querySelector<HTMLElement>('[data-icono="suena"]')!.hidden = v.muted;
+			// Un SVGElement NO tiene la propiedad `hidden`: asignarla no oculta nada.
+			// Medido: `'hidden' in svg` es false. Hay que usar el atributo.
+			const mudo = sonido.querySelector('[data-icono="mudo"]')!;
+			const suena = sonido.querySelector('[data-icono="suena"]')!;
+			mudo.toggleAttribute("hidden", !v.muted);
+			suena.toggleAttribute("hidden", v.muted);
 		});
 
 		// Cerrar deslizando hacia abajo. Solo se toma el gesto cuando es claramente


### PR DESCRIPTION
Los dos que quedaban del visor en móvil. **Ninguno era lo que parecía**, y los dos se localizaron midiendo, no leyendo el código.

## El toque no llegaba a la barra de reproducción

La barra funcionaba. Lo que fallaba es que **el toque lo recibía otro elemento**: `viewer-bar`, la fila de «1 de 1» y las flechas, que se pinta después en el DOM y cubre esa franja.

Localizado preguntando con `elementFromPoint` qué hay bajo el centro de la barra:

```
antes:   recibe el toque -> viewer-bar
después: recibe el toque -> viewer-progreso
```

Se resuelve con un `z-index`. Verificado con un arrastre real: el vídeo salta de **2,6 s a 8,4 s** de 11,6.

## El icono de sonido no cambiaba

Porque **los elementos SVG no tienen la propiedad `hidden`**. Medido en el navegador:

```
'hidden' in svg  ->  false
```

Así que `svg.hidden = true` creaba una propiedad JavaScript inerte y no ocultaba nada. En un elemento HTML habría funcionado; en SVG hay que usar el atributo. Es un fallo que no se ve leyendo el código, porque la línea parece correcta.

Verificado alternando en los dos sentidos:

```
muted=true   -> icono mudo VISIBLE
al pulsar    -> muted=false, icono suena VISIBLE
al repulsar  -> muted=true,  icono mudo VISIBLE
```

## Verificado

`pnpm verify:viewer` en código 0, `check:links` en verde, y las dos interacciones comprobadas con arrastre y pulsación reales en lugar de inspeccionar estilos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQ3fpT2Ck2fq8HqqJ5vtr
