### PR TITLE
feat(admin): modo edición del portfolio y contenido editable

### DIFF
--- a/docs/admin-puesta-en-marcha.md
+++ b/docs/admin-puesta-en-marcha.md
@@ -1,0 +1,93 @@
+# Modo edición del portfolio
+
+Página en `/admin` para que Luisa reordene proyectos y fotos, elija portadas y
+oculte lo que no quiera enseñar, sin tocar código ni ficheros.
+
+## Qué puede hacer y qué no
+
+**Puede**: reordenar proyectos, reordenar las fotos de cada proyecto, marcar una
+foto como portada, ocultar fotos, destacar un proyecto en la home, fijar un
+proyecto al principio o al final de su listado, y corregir título y descripción.
+
+**No puede**: cambiar el rol, la estilista principal ni los créditos. Esos campos
+están declarados pero ocultos en la configuración, así que se conservan intactos
+y no aparecen en pantalla. La atribución de cada trabajo se decide fuera del CMS.
+
+**Tampoco puede subir fotos.** Las imágenes del sitio pasan por
+`scripts/optimize-gallery.mjs`, que las convierte a webp de 2048px. Una foto
+subida desde el CMS entraría cruda de cámara y dispararía el peso del sitio, que
+ya roza el límite de tiempo de despliegue. Añadir material sigue siendo tarea de
+David con el script.
+
+## Cómo funciona por dentro
+
+Cada proyecto lleva en su JSON una lista `gallery` de objetos:
+
+```json
+{ "file": "/assets/editorials/artego-color-pop-garden/1.webp", "cover": true }
+```
+
+- **El orden del array es el orden de la galería.** Ya no se deduce del nombre
+  del fichero, que era lo que obligaba a renombrar en cadena para reordenar.
+- **`cover: true`** marca la portada. Antes la portada era un fichero llamado
+  `index.webp` que había que copiar encima de otro.
+- **`hidden: true`** la saca del portfolio **sin borrar nada**. Es reversible.
+
+La ruta se guarda completa, no solo el nombre, porque si no el CMS no sabe dónde
+está la imagen y la muestra como texto en vez de como miniatura.
+
+## Lo que falta para ponerlo en marcha
+
+### 1. El servicio de autenticación
+
+Sveltia CMS necesita un intermediario que haga el baile de OAuth con GitHub. Hay
+uno oficial listo para Cloudflare Workers, que ya usáis para el dominio:
+
+<https://github.com/sveltia/sveltia-cms-auth>
+
+Pasos, todos en cuentas de David:
+
+1. Crear una **OAuth App** en GitHub (Settings → Developer settings → OAuth Apps).
+   La URL de callback es la del Worker, `https://<worker>.workers.dev/callback`.
+2. Desplegar el Worker con `GITHUB_CLIENT_ID` y `GITHUB_CLIENT_SECRET` como
+   variables de entorno.
+3. Añadir a `public/admin/config.yml`, dentro de `backend`:
+
+   ```yaml
+   base_url: https://<worker>.workers.dev
+   ```
+
+### 2. Quién entra
+
+Solo pueden guardar las cuentas con permiso de escritura en el repositorio.
+
+Lo recomendable es **invitar a Luisa como colaboradora** con una cuenta suya
+gratuita: los cambios quedan a su nombre y el acceso se revoca en un clic sin
+tocar nada más.
+
+Si en su lugar usa la cuenta de David, funciona igual, pero conviene saber que
+eso le da acceso a **toda** la cuenta de GitHub, no solo a este repositorio, y
+que los commits saldrán firmados por David.
+
+### 3. Publicación
+
+`publish_mode: editorial_workflow` está activado: cada cambio abre una rama y una
+propuesta en vez de publicar directo. Luisa trabaja a su ritmo y se publica
+cuando alguien lo ha revisado.
+
+No es solo prudencia: cada publicación dispara un despliegue de más de diez
+minutos, y GitHub Pages limita cuántos admite por hora. Publicar en cada guardado
+reventaría el despliegue en una tarde de ajustes.
+
+## Probarlo en local, sin autenticación
+
+Con `local_backend: true` en la configuración, el CMS puede leer y escribir los
+ficheros del repositorio en la máquina de desarrollo:
+
+```
+pnpm dlx decap-server     # deja un proxy escuchando en el puerto 8081
+pnpm dev                  # y el sitio en el 4321
+```
+
+Después, `http://localhost:4321/admin/`. Sveltia pedirá elegir la carpeta del
+repositorio; Decap se conecta al proxy directamente.

--- a/docs/admin-puesta-en-marcha.md
+++ b/docs/admin-puesta-en-marcha.md
@@ -13,11 +13,14 @@ proyecto al principio o al final de su listado, y corregir título y descripció
 están declarados pero ocultos en la configuración, así que se conservan intactos
 y no aparecen en pantalla. La atribución de cada trabajo se decide fuera del CMS.
 
-**Tampoco puede subir fotos.** Las imágenes del sitio pasan por
-`scripts/optimize-gallery.mjs`, que las convierte a webp de 2048px. Una foto
-subida desde el CMS entraría cruda de cámara y dispararía el peso del sitio, que
-ya roza el límite de tiempo de despliegue. Añadir material sigue siendo tarea de
-David con el script.
+**No debería subir fotos nuevas, aunque el CMS lo permite.** El campo de foto es
+un `widget: image` normal, así que técnicamente sí se puede subir una imagen
+desde ahí; es una convención, no una restricción del propio CMS. Las imágenes
+del sitio pasan por `scripts/optimize-gallery.mjs`, que las convierte a webp de
+2048px, y una foto subida directamente desde el CMS entraría cruda de cámara
+(sin optimizar, mucho más pesada) y quedaría así en el repositorio, empujando el
+peso del sitio hacia el límite de tiempo de despliegue. Añadir material sigue
+siendo tarea de David con el script.
 
 ## Cómo funciona por dentro
 

--- a/docs/admin-puesta-en-marcha.md
+++ b/docs/admin-puesta-en-marcha.md
@@ -73,15 +73,8 @@ en Cloudflare Workers y solo hay que añadir `base_url` a la configuración. Par
 una sola usuaria es montar un servicio para nada, y además quedará obsoleto
 cuando GitHub publique el estándar que tiene en preparación.
 
-## Probarlo en local, sin autenticación
+## Probarlo en local
 
-Con `local_backend: true` en la configuración, el CMS puede leer y escribir los
-ficheros del repositorio en la máquina de desarrollo:
-
-```
-pnpm dlx decap-server     # deja un proxy escuchando en el puerto 8081
-pnpm dev                  # y el sitio en el 4321
-```
-
-Después, `http://localhost:4321/admin/`. Sveltia pedirá elegir la carpeta del
-repositorio; Decap se conecta al proxy directamente.
+Sveltia no usa proxy: ignora la opción `local_backend`. Se abre
+`http://localhost:4321/admin/` y se pulsa **Work with Local Repository**, que
+pide elegir la carpeta del repositorio. Necesita un navegador basado en Chromium.

--- a/docs/admin-puesta-en-marcha.md
+++ b/docs/admin-puesta-en-marcha.md
@@ -36,48 +36,42 @@ Cada proyecto lleva en su JSON una lista `gallery` de objetos:
 La ruta se guarda completa, no solo el nombre, porque si no el CMS no sabe dónde
 está la imagen y la muestra como texto en vez de como miniatura.
 
-## Lo que falta para ponerlo en marcha
+## Cómo se publica
 
-### 1. El servicio de autenticación
+**El CMS escribe en la rama `contenido`, no en `main`.** Sveltia todavía no
+soporta el flujo editorial de Decap, así que sin esto cada guardado iría directo
+a producción y dispararía un despliegue de más de diez minutos, con el límite de
+despliegues por hora de GitHub Pages de por medio.
 
-Sveltia CMS necesita un intermediario que haga el baile de OAuth con GitHub. Hay
-uno oficial listo para Cloudflare Workers, que ya usáis para el dominio:
+Con la rama aparte:
 
-<https://github.com/sveltia/sveltia-cms-auth>
+1. Luisa guarda tantos cambios como quiera. **No se despliega nada**, porque el
+   workflow solo se dispara con `main`.
+2. Cuando está conforme, David abre un PR de `contenido` a `main`, lo revisa y lo
+   mergea. Ahí se publica todo junto, en un solo despliegue.
+3. Después conviene poner `contenido` al día con `main`, para que no se separen.
 
-Pasos, todos en cuentas de David:
+## Cómo entra Luisa
 
-1. Crear una **OAuth App** en GitHub (Settings → Developer settings → OAuth Apps).
-   La URL de callback es la del Worker, `https://<worker>.workers.dev/callback`.
-2. Desplegar el Worker con `GITHUB_CLIENT_ID` y `GITHUB_CLIENT_SECRET` como
-   variables de entorno.
-3. Añadir a `public/admin/config.yml`, dentro de `backend`:
+**No hace falta ni OAuth App ni Worker.** Sveltia permite entrar con un token
+personal, y para una sola usuaria es el camino corto.
 
-   ```yaml
-   base_url: https://<worker>.workers.dev
-   ```
+1. Luisa se crea una cuenta de GitHub gratuita.
+2. David la invita como colaboradora del repositorio. En repositorios personales
+   no hay selector de permisos: un colaborador tiene escritura por defecto.
+3. Ella genera el token en **Settings → Developer settings → Personal access
+   tokens → Tokens (classic)**, con el permiso `repo` marcado.
 
-### 2. Quién entra
+   Tiene que ser un token **clásico**: GitHub no admite los nuevos de permisos
+   finos para colaboradores de repositorios ajenos. El token se muestra una sola
+   vez, así que hay que guardarlo al crearlo.
+4. En `luisabenitez.es/admin`, botón **Sign In with Token**, y pegarlo.
 
-Solo pueden guardar las cuentas con permiso de escritura en el repositorio.
-
-Lo recomendable es **invitar a Luisa como colaboradora** con una cuenta suya
-gratuita: los cambios quedan a su nombre y el acceso se revoca en un clic sin
-tocar nada más.
-
-Si en su lugar usa la cuenta de David, funciona igual, pero conviene saber que
-eso le da acceso a **toda** la cuenta de GitHub, no solo a este repositorio, y
-que los commits saldrán firmados por David.
-
-### 3. Publicación
-
-`publish_mode: editorial_workflow` está activado: cada cambio abre una rama y una
-propuesta en vez de publicar directo. Luisa trabaja a su ritmo y se publica
-cuando alguien lo ha revisado.
-
-No es solo prudencia: cada publicación dispara un despliegue de más de diez
-minutos, y GitHub Pages limita cuántos admite por hora. Publicar en cada guardado
-reventaría el despliegue en una tarde de ajustes.
+Si algún día son varias personas y pegar el token molesta, el
+[autenticador oficial](https://github.com/sveltia/sveltia-cms-auth) se despliega
+en Cloudflare Workers y solo hay que añadir `base_url` a la configuración. Para
+una sola usuaria es montar un servicio para nada, y además quedará obsoleto
+cuando GitHub publique el estándar que tiene en preparación.
 
 ## Probarlo en local, sin autenticación
 

--- a/docs/research-inditex.md
+++ b/docs/research-inditex.md
@@ -1,0 +1,140 @@
+# Investigación: candidatura de Luisa Benítez a estilismo en Zara (Inditex)
+
+Fecha: agosto de 2026. Encargo de David. Este documento separa en cada punto lo **verificado** (con fuente) de lo **inferido** (deducción razonable sin fuente directa). Las decisiones sobre el CV las toman David y Luisa; aquí solo hay hallazgos y recomendaciones.
+
+---
+
+## Bloque 1: cómo se entra en Inditex
+
+### 1.1 El canal: portal propio, no agregadores
+
+**Verificado.** El portal de empleo oficial es hoy **inditexpeople.com**. El dominio antiguo `inditexcareers.com` redirige ahí con un 301 (comprobado en agosto de 2026). La candidatura se hace con cuenta propia en el portal: login, formulario y subida de CV. Para perfiles creativos la plataforma pide además **subir el portfolio** (en el Graduate Program el CV tiene un límite de 3,5 MB y el portfolio se sube como pieza aparte).
+
+Inditex también publica ofertas en LinkedIn, BoF Careers y agregadores (Wizbii, Jooble), pero el flujo termina siempre en su plataforma.
+
+### 1.2 El proceso de selección real
+
+**Verificado, con matices.** El proceso documentado varía mucho entre tienda y oficinas:
+
+- **Tienda (retail)**: preselección de CV, dinámica grupal con 15-20 candidatos, entrevista individual que puede ser en inglés según el puesto. En Italia usan VideoAsk (videoentrevista asíncrona) vía una ETT; no hay evidencia de que ese paso exista en España.
+- **Corporativo / oficinas**: solicitud online, en algunos puestos tests de razonamiento (numérico, verbal, lógico), entrevista con RRHH y entrevista técnica con el equipo. Duración típica de entrevista: 30-45 minutos. Según Glassdoor, el proceso completo dura de media unos 15 días y el 71% de los candidatos lo valora como positivo, con dificultad media-baja (2,2/5).
+- **Entrevistas de estilismo**: hay testimonios en Glassdoor de **ejercicios prácticos**: vestir a un cliente con un presupuesto y defender las elecciones ante el grupo, o componer looks con tablets usando producto de marcas Inditex. Es entrevista por competencias más prueba práctica, no solo conversación.
+
+**Inferido**: para una vacante de estilista en sede, lo esperable es RRHH + entrevista técnica con el equipo de imagen, muy probablemente con revisión del portfolio en directo y algún ejercicio de composición de looks. Conviene que Luisa prepare el método STAR para las conductuales y que llegue con criterio articulado sobre producto Zara (por qué funciona un look de Zara.com, no solo por qué es bonito).
+
+### 1.3 La vía específica para creativos: el Graduate Program
+
+**Verificado.** Inditex tiene un programa anual para creativos (`talent.inditexpeople.com/en/creatives/`) dirigido a estudiantes de último año o **recién graduados** en Diseño de Moda, **Estilismo**, Dirección de Arte, Fotografía, etc. Fases: candidatura con portfolio, entrevistas en mayo, final ("The Show") en la sede en junio, incorporación entre julio y octubre. Contrato pagado de un año, sedes en A Coruña, Barcelona y Alicante, y el 80% de los participantes se queda en equipos de Inditex. Piden disponibilidad para **reubicarse a A Coruña**.
+
+**Relevante para Luisa**: terminó Asesoría de Imagen en Davante en noviembre de 2025, así que técnicamente es titulada reciente, aunque con cinco años de experiencia va sobrada para el perfil de entrada. Es una segunda puerta si la vacante directa no sale: la convocatoria de 2027 abriría a principios de año con entrevistas en mayo.
+
+### 1.4 Cómo son las ofertas de estilismo publicadas
+
+Dos ofertas reales localizadas, y coinciden mucho entre sí:
+
+**Zara, "Fashion Stylist" (sede, publicada en BoF Careers):**
+- Función: crear los **looks de Zara.com** en colaboración con los equipos de imagen y set: fotógrafos, modelos, directores de arte y **product managers**. Trabajo codo a codo con los equipos Woman, Man y Kids. Búsqueda de referencias de imagen.
+- Requisitos: **+2 años de experiencia como estilista** (fashion shows, editorial, **lookbooks, e-commerce**), interés por la cultura contemporánea (moda, diseño, fotografía, arte), y **portfolio digital** (web, blog).
+- Perfil buscado, literal: "strongly fashion-orientated, dynamic, flexible and team workers".
+
+**Bershka, "Estilista de Moda eCommerce" (Tordera, BKNE24048):**
+- Función: "creación de los looks para las fotos de e-Commerce" y colaboración en el **lookbook**.
+- Requisitos: mínimo 2 años en puesto similar, **inglés nivel alto imprescindible**, estudios relacionados con moda, **disponibilidad para viajar**.
+
+Lectura de lo que se repite: experiencia acreditable de 2+ años (Luisa la cumple con margen), vocabulario de **e-commerce, lookbook, shooting y equipo** (no solo editorial), portfolio digital obligatorio, e inglés. El contexto físico de la vacante Zara existe y está descrito en prensa: los estudios de Zara.com en Arteixo, un edificio de 67.000 m² con platós de luz natural donde fotógrafos, estilistas y maquilladores producen la imagen de zara.com. Ese estudio es el destino natural del perfil de Luisa.
+
+### 1.5 La hipótesis del ATS: no confirmada
+
+**Esto contradice una premisa del proyecto y hay que decirlo claro.** No he encontrado ninguna fuente que confirme qué ATS usa Inditex ni que aplique **cribado automático por palabras clave** a los CV. Los artículos que afirman "Inditex usa SuccessFactors/Workday" son blogs de plantillas de CV sin fuente primaria; no los doy por buenos. Lo observable: el portal es desarrollo propio (Next.js), con subida de CV y formulario estructurado.
+
+Consecuencias prácticas:
+
+1. **El diseño actual del CV (una columna, texto real, sin gráficos) sigue siendo correcto**, porque cualquier portal con parser de CV agradece un documento limpio, y porque un CV sobrio no perjudica ante un humano. No hay que rehacerlo.
+2. Pero **el énfasis defensivo está mal puesto**: para una vacante creativa de Inditex el filtro real documentado es el **portfolio digital** y, en segundo lugar, el inglés. El CV pasa la criba; el portfolio decide. La energía de optimización debería ir a que luisabenitez.es esté impecable y a que el enlace sea imposible de no ver.
+3. Las "keywords" siguen importando, pero por el lector humano: un recruiter de Inditex escanea buscando e-commerce, lookbook, campañas, equipo. Eso sí hay que dárselo (ver bloque 2).
+
+---
+
+## Bloque 2: qué debe cambiar en el CV para esta vacante
+
+Estado actual: Perfil · Experiencia · Formación · Servicios · Publicaciones · Idiomas, una columna, un folio. Lo que sigue va de más a menos importante.
+
+### 2.1 Reformular Grupo Crystal: es la credencial Inditex y está desaprovechada
+
+La entrada actual dice solo "Marcas del grupo: Gef, Punto Blanco, Baby Fresh y Galax". Para un recruiter de Zara.com esa es **la línea más relevante del CV** y no cuenta nada: la vacante tipo es producir looks en un estudio de e-commerce, y Luisa pasó un año dentro del flujo de imagen de un grupo textil de gran consumo, exactamente el entorno de los platós de Arteixo, solo que desde la edición fotográfica.
+
+- **No moverla de posición**: el CV es cronológico inverso y romper eso confunde. Su sitio cronológico es el último.
+- **Sí ampliarla**: qué hacía (edición y selección de imagen de moda para las marcas del grupo, para qué canales, con qué equipos: fotógrafos, dirección de arte, producto), y si hay números reales (volumen de imágenes, campañas, marcas por temporada), usarlos. Confirmar los detalles con Luisa antes de escribir nada.
+- **Y sobre todo, subirla al Perfil**: el párrafo de perfil actual no menciona Grupo Crystal ni la palabra e-commerce. Ahí es donde el recruiter la tiene que ver en los primeros cinco segundos: algo como "empecé dentro del equipo de imagen de Grupo Crystal, el grupo textil colombiano de Gef y Punto Blanco" conecta su origen con el mundo Zara sin inflar el rol.
+
+### 2.2 Meter el vocabulario de las ofertas donde sea verdad
+
+Palabras que las dos ofertas repiten y que hoy no aparecen (o casi) en el CV: **e-commerce, lookbook, looks, shooting/sesión, equipo (fotógrafos, dirección de arte, producto), referencias de imagen**. El CV actual está escrito en clave editorial y celebrity, que es su historial real, pero varias entradas admiten esta capa sin mentir:
+
+- La entrada de agencia ya cita campañas (YSL, Kérastase, GHD...): son shootings comerciales con producto como protagonista, que es la sensibilidad que Zara pide. Puede decirse así.
+- Si en los 20 proyectos de agencia o los 11 propios hubo lookbooks o contenido para tienda online de alguna marca, nombrarlo explícitamente. Confirmar con Luisa.
+- El texto de About ya contiene la idea perfecta para esta candidatura: "una campaña pide que el producto sea el protagonista y que el estilismo sepa apartarse". Esa frase, resumida, merece estar en el perfil del CV para Inditex.
+
+### 2.3 Sustituir "Servicios" por competencias
+
+"Servicios" (con "Personal shopper", "Asesoría de imagen") es lenguaje de freelance que vende a clientes; a un empleador le dice poco y gasta sitio. Para la versión Inditex del CV:
+
+- Quitar o reconvertir en una línea de **competencias**: fitting, composición de looks, lookbook, preparación de shooting, moodboards y referencias, gestión de showroom y alquiler de vestuario (eso lo acredita Elástica Films), coordinación con fotografía y dirección de arte.
+- "Asesoría de imagen" puede sobrevivir como titulación (ya está en Formación), no como servicio.
+
+### 2.4 El enlace al portfolio tiene que ser inequívoco
+
+Las ofertas creativas de Inditex piden portfolio digital de forma explícita. En el CV actual la web va en la línea de contacto como `@instagram · luisabenitez.es`, en formato pareja. Recomendación: etiquetarlo, "Portfolio: luisabenitez.es", aunque cueste tres caracteres más. Es el documento que decide la entrevista; no puede parecer un dato de contacto más.
+
+### 2.5 A Coruña: ventaja real, y conviene explotarla sin subrayarla en exceso
+
+**Verificado**: el Graduate Program exige a los candidatos disponibilidad para reubicarse a A Coruña, y las ofertas de sede piden residencia o disponibilidad en la zona (la de Bershka exigía residencia en Barcelona para Tordera). Es decir, la ubicación es un filtro real en Inditex, y Luisa lo pasa de fábrica: incorporación inmediata, sin coste de reubicación, sin periodo de adaptación a la ciudad.
+
+- El CV ya dice "A Coruña, España" en la cabecera: suficiente como dato.
+- Donde vale oro es en el **perfil o la carta**: una frase tipo "resido en A Coruña, con disponibilidad inmediata para incorporarme en Arteixo" convierte el dato pasivo en argumento. No hace falta decir "a quince minutos": el recruiter de Arteixo sabe dónde está A Coruña.
+
+### 2.6 El inglés B1 es el punto débil objetivo: no maquillarlo, pero atacarlo
+
+La oferta de Bershka pedía "inglés nivel alto imprescindible" y las entrevistas de Inditex pueden ser en inglés según el puesto. B1 es el requisito que Luisa no cumple del todo hoy. En el CV: dejarlo como está (B1, honesto), porque inflarlo se descubre en la primera entrevista en inglés. Fuera del CV: es la inversión de mayor retorno antes de candidatarse; si está estudiando o tiene certificación en curso, esa línea sí puede añadirse ("en progreso hacia B2").
+
+### 2.7 Lo que NO hay que tocar
+
+- **El formato**: una columna, un folio, texto seleccionable, sin foto. Correcto para el portal y para el lector; el peso visual lo lleva el portfolio, no el CV. La investigación no da motivo para rehacerlo.
+- **La honestidad de títulos** (auxiliar de vestuario en prácticas, técnico laboral de Cesde): las fuentes coinciden en que Inditex verifica y hace entrevista técnica; los títulos sin inflar son un activo.
+- **Publicaciones**: mantener. Numéro, Vogue Adria y GQ son señal de nivel inmediata para un recruiter de moda.
+- **El orden general** Perfil · Experiencia · Formación · Idiomas: estándar y correcto.
+
+### 2.8 Resumen accionable
+
+| Acción | Qué | Por qué |
+|---|---|---|
+| Reescribir | Summary de Grupo Crystal, con detalle de funciones y equipos | Es la experiencia más Zara del historial y hoy es una línea vacía |
+| Reescribir | Perfil: añadir Grupo Crystal, e-commerce y sensibilidad comercial-producto | Primeros cinco segundos del recruiter |
+| Añadir | Vocabulario de ofertas (lookbook, e-commerce, shooting, equipo) donde sea cierto | Es lo que el lector humano escanea |
+| Sustituir | "Servicios" por línea de competencias de estilismo | Lenguaje de empleado, no de freelance |
+| Cambiar | Etiquetar "Portfolio: luisabenitez.es" en cabecera | El portfolio es el filtro real para creativos |
+| Añadir | Disponibilidad inmediata en Arteixo (perfil o carta) | La ubicación es filtro real en Inditex y Luisa lo cumple |
+| Mantener | Formato de una columna, títulos honestos, Publicaciones, B1 sin inflar | Nada en la investigación pide cambiarlo |
+| Preparar (fuera del CV) | Inglés hacia B2, portfolio impecable, ejercicio práctico de looks con producto Inditex | Son los filtros que sí están documentados |
+
+---
+
+## Qué no he podido confirmar
+
+- **El ATS de Inditex**: ni el proveedor ni la existencia de cribado automático por palabras clave. La premisa de diseño del CV queda como precaución razonable, no como hecho.
+- **La vigencia actual** de las dos ofertas de estilismo citadas (la de BoF devuelve 403 al acceso directo; el texto se recuperó de resultados indexados). Sirven como muestra de redacción y requisitos, no como vacantes abiertas hoy.
+- **Testimonios específicos** de procesos de estilista en la sede de Arteixo: los testimonios prácticos de entrevistas de estilismo encontrados son mayoritariamente de retail y de otras plazas.
+- Que las entrevistas de sede incluyan siempre prueba en inglés: hay indicios ("puede ser en inglés según el puesto"), no confirmación.
+
+## Fuentes
+
+- Portal de empleo oficial (redirección verificada desde inditexcareers.com): https://www.inditexpeople.com/
+- Graduate Program, perfiles creativos (incluye Estilismo, portfolio, fases y sedes): https://talent.inditexpeople.com/en/creatives/
+- Oferta Zara "Fashion Stylist" en BoF Careers: https://www.businessoffashion.com/careers/jobs/creative/spain/zara/fashion-stylist-1
+- Oferta Bershka "Estilista de Moda eCommerce" (Tordera), vía Wizbii: https://es.wizbii.com/company/inditex/job/estilista-de-moda-ecommerce-tordera-barcelona-spain
+- Ejemplo de oferta retail en portal propio (proceso con VideoAsk, Italia): https://www.inditexpeople.com/de/de/joinus/offers/ITAGTT5528
+- Estudios de Zara.com en Arteixo: https://www.elespanol.com/invertia/empresas/distribucion/20200614/zara-trae-hollywood-arteixo-monta-propios-estudios/496951443_0.html y https://revistacentroscomerciales.com/noticias/archivo/listo-el-nuevo-edificio-de-zara-en-arteixo/
+- Proceso de selección y fases (corporativo, tests, entrevistas): https://blog.assessment-training.com/es/preguntas-de-entrevista/inditex-preguntas-entrevista
+- Proceso de selección retail (grupal + individual, entrevista en inglés según puesto): https://www.campustraining.es/noticias/como-trabajar-inditex/
+- Experiencias de entrevista, duración y ejercicios prácticos de estilismo: https://www.glassdoor.com/Interview/Inditex-Interview-Questions-E12213.htm y https://es.indeed.com/cmp/Inditex/interviews
+- Opiniones sobre trabajar en la sede de Arteixo: https://www.glassdoor.com/Reviews/Inditex-Arteixo-Reviews-EI_IE12213.0,7_IL.8,15_IC4845681.htm

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -55,6 +55,17 @@ campos_proyecto: &campos_proyecto
   - { name: leadStylist, widget: hidden, required: false }
   - { name: format, widget: hidden, required: false }
   - { name: credits, widget: hidden, required: false }
+  # No hay copy todavía para ninguno de estos seis, pero el esquema
+  # (content.config.ts) ya los admite y algunas plantillas los consumen. Si no
+  # se declaran aquí, el primer guardado del CMS después de que alguien los
+  # escriba a mano los borraría del JSON, porque una colección "files"
+  # reescribe el fichero entero solo con los campos que conoce.
+  - { name: descriptionEn, widget: hidden, required: false }
+  - { name: roleDetail, widget: hidden, required: false }
+  - { name: year, widget: hidden, required: false }
+  - { name: season, widget: hidden, required: false }
+  - { name: client, widget: hidden, required: false }
+  - { name: publication, widget: hidden, required: false }
 
 collections:
   - name: editoriales

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -11,12 +11,12 @@ local_backend: true
 backend:
   name: github
   repo: davidarce/portfolio-luisa-benitez
-  branch: main
-
-# Cada cambio abre una rama y una propuesta en vez de publicar directo. Así
-# Luisa trabaja a su ritmo y se publica cuando alguien lo ha visto. También evita
-# que quince ajustes seguidos disparen quince despliegues de diez minutos.
-publish_mode: editorial_workflow
+  # El CMS escribe en una rama de contenido, NO en main. Sveltia todavía no
+  # soporta el flujo editorial de Decap (lo anuncian para su 1.0), así que sin
+  # esto cada guardado iría directo a producción y dispararía un despliegue de
+  # diez minutos. Con la rama aparte, Luisa trabaja a su ritmo sin desplegar
+  # nada y se publica todo junto con un PR de `contenido` a `main`.
+  branch: contenido
 
 media_folder: public/assets
 public_folder: /assets

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,0 +1,135 @@
+# Configuración de Sveltia CMS. La página vive en /admin y no hace nada sin
+# iniciar sesión en GitHub: los cambios se guardan como commits en el repositorio.
+#
+# CUIDADO al tocar este fichero: en una colección de tipo "files", el CMS
+# reescribe el JSON entero con los campos declarados aquí. Un campo que exista
+# en el JSON y NO esté declarado se pierde al guardar. Por eso están todos, y
+# los que no debe tocar nadie van como `hidden`: se conservan sin mostrarse.
+
+local_backend: true
+
+backend:
+  name: github
+  repo: davidarce/portfolio-luisa-benitez
+  branch: main
+
+# Cada cambio abre una rama y una propuesta en vez de publicar directo. Así
+# Luisa trabaja a su ritmo y se publica cuando alguien lo ha visto. También evita
+# que quince ajustes seguidos disparen quince despliegues de diez minutos.
+publish_mode: editorial_workflow
+
+media_folder: public/assets
+public_folder: /assets
+
+locale: es
+
+# El rol, la estilista principal y los créditos NO se editan desde aquí. La
+# atribución de cada trabajo se decide fuera del CMS: un clic accidental no
+# puede convertir una asistencia en un estilismo propio.
+campos_proyecto: &campos_proyecto
+  - { name: title, label: Título, widget: string }
+  - { name: description, label: Descripción, widget: text, required: false }
+  - name: gallery
+    label: Fotos y vídeos
+    label_singular: foto
+    widget: list
+    collapsed: false
+    summary: '{{fields.file}}'
+    fields:
+      - { name: file, label: Foto, widget: image }
+      - { name: hidden, label: Ocultar del portfolio, widget: boolean, required: false, default: false }
+      - { name: cover, label: Usar como portada, widget: boolean, required: false, default: false }
+  - { name: featured, label: Destacar en la portada del sitio, widget: boolean, required: false }
+  - name: pin
+    label: Fijar en el listado
+    widget: select
+    required: false
+    options:
+      - { label: 'Sin fijar', value: '' }
+      - { label: 'Al principio', value: first }
+      - { label: 'Al final', value: last }
+  - { name: id, widget: hidden }
+  - { name: img, widget: hidden, required: false }
+  - { name: img_alt, widget: hidden }
+  - { name: cardSize, widget: hidden }
+  - { name: order, widget: hidden }
+  - { name: role, widget: hidden }
+  - { name: leadStylist, widget: hidden, required: false }
+  - { name: format, widget: hidden, required: false }
+  - { name: credits, widget: hidden, required: false }
+
+collections:
+  - name: editoriales
+    label: Editoriales
+    files:
+      - name: lista
+        label: Editoriales
+        file: src/content/editorials/editorials.json
+        fields:
+          - name: highlighted
+            label: Proyectos
+            label_singular: proyecto
+            widget: list
+            collapsed: true
+            summary: '{{fields.title}}'
+            fields: *campos_proyecto
+
+  - name: campanas
+    label: Campañas
+    files:
+      - name: lista
+        label: Campañas
+        file: src/content/publicity/publicity.json
+        fields:
+          - name: highlighted
+            label: Proyectos
+            label_singular: proyecto
+            widget: list
+            collapsed: true
+            summary: '{{fields.title}}'
+            fields: *campos_proyecto
+
+  - name: celebridades
+    label: Celebridades y eventos
+    files:
+      - name: lista
+        label: Celebridades y eventos
+        file: src/content/celebrities/celebrities.json
+        fields:
+          - name: highlighted
+            label: Proyectos
+            label_singular: proyecto
+            widget: list
+            collapsed: true
+            summary: '{{fields.title}}'
+            fields: *campos_proyecto
+
+  - name: pasarela
+    label: Runway
+    files:
+      - name: lista
+        label: Runway
+        file: src/content/runway/runway.json
+        fields:
+          - name: highlighted
+            label: Proyectos
+            label_singular: proyecto
+            widget: list
+            collapsed: true
+            summary: '{{fields.title}}'
+            fields: *campos_proyecto
+
+  - name: cine
+    label: Cine
+    files:
+      - name: lista
+        label: Cine
+        file: src/content/films/films.json
+        fields:
+          - name: highlighted
+            label: Proyectos
+            label_singular: proyecto
+            widget: list
+            collapsed: true
+            summary: '{{fields.title}}'
+            fields: *campos_proyecto

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -6,8 +6,6 @@
 # en el JSON y NO esté declarado se pierde al guardar. Por eso están todos, y
 # los que no debe tocar nadie van como `hidden`: se conservan sin mostrarse.
 
-local_backend: true
-
 backend:
   name: github
   repo: davidarce/portfolio-luisa-benitez

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -13,6 +13,14 @@
 			decide GitHub, y solo las cuentas con permiso de escritura en el
 			repositorio pueden hacerlo.
 		-->
-		<script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js" type="module"></script>
+		<!--
+			Versión fijada (no "@sveltia/cms/dist/..." a secas): esta página es
+			donde Luisa pega un token de GitHub con permiso de escritura, así que
+			cargar "lo último que haya" en ese momento sin control de versión sería
+			exponer ese token a cualquier cambio que suba el paquete, sin aviso ni
+			revisión. Comprobar periódicamente si hay una versión más reciente y
+			subir el número a mano tras probarla.
+		-->
+		<script src="https://unpkg.com/@sveltia/cms@0.180.1/dist/sveltia-cms.js" type="module"></script>
 	</body>
 </html>

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="es">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="robots" content="noindex, nofollow" />
+		<title>Editar el portfolio</title>
+	</head>
+	<body>
+		<!--
+			La página es pública porque GitHub Pages gratuito exige repositorio
+			público, pero sin iniciar sesión no hace nada: quién puede guardar lo
+			decide GitHub, y solo las cuentas con permiso de escritura en el
+			repositorio pueden hacerlo.
+		-->
+		<script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js" type="module"></script>
+	</body>
+</html>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,17 +1,25 @@
 import { defineCollection, z } from 'astro:content';
 import { createGalleryLoader } from './loaders/gallery-loader';
 
+// El widget "Sin fijar" del CMS (y cualquier otro select/texto que la usuaria
+// vacíe) escribe `""` en vez de omitir el campo. Zod trata `""` como un
+// string válido, no como "ausente", así que un `.optional()` a secas no basta:
+// hay que normalizar `""` a `undefined` antes de validar. Se aplica a todo
+// campo opcional del esquema, no solo a `pin`, porque el CMS puede vaciar
+// cualquiera de ellos de la misma forma.
+const optional = <T extends z.ZodTypeAny>(schema: T) =>
+	z.preprocess((val) => (val === '' ? undefined : val), schema.optional());
+
 const gallerySchema = z.object({
 	title: z.string(),
-	description: z.string().optional(),
+	description: optional(z.string()),
 	/** Vacía a propósito hoy: la copy de proyecto es de Luisa y no se inventa. Las plantillas hacen `descriptionEn ?? description`. */
-	descriptionEn: z.string().optional(),
+	descriptionEn: optional(z.string()),
 	img: z.string(),
-	img_alt: z.string().optional(),
-	video: z.string().optional(),
+	img_alt: optional(z.string()),
 	cardSize: z.enum(['normal', 'tall', 'wide']).default('normal'),
 	aspectRatio: z.string().default('3 / 4'),
-	objectPosition: z.string().optional(),
+	objectPosition: optional(z.string()),
 	images: z.array(z.string()),
 	// Fuente del orden y la visibilidad de `images`: el CMS edita este campo,
 	// no el sistema de ficheros. Ocultar una foto no la borra del disco.
@@ -37,35 +45,37 @@ const gallerySchema = z.object({
 	featured: z.boolean().optional(),
 
 	// Ancla un proyecto al principio o al final de SU listado, por encima del
-	// orden por rol. Decisión editorial explícita, no automatismo.
-	pin: z.enum(['first', 'last']).optional(),
+	// orden por rol. Decisión editorial explícita, no automatismo. `optional()`
+	// (no `.optional()` a secas) para tragar el "Sin fijar" del CMS, que
+	// escribe `pin: ""` en vez de omitir el campo.
+	pin: optional(z.enum(['first', 'last'])),
 
 	role: z.enum(['lead-stylist', 'assistant-stylist', 'wardrobe-assistant', 'co-stylist']),
-	roleDetail: z.string().optional(),
-	leadStylist: z.string().optional(),
+	roleDetail: optional(z.string()),
+	leadStylist: optional(z.string()),
 
-	year: z.number().optional(),
-	season: z.string().optional(),
-	client: z.string().optional(),
-	publication: z.string().optional(),
-	format: z.enum(['editorial', 'campaign', 'social', 'runway', 'event', 'film', 'model-test']).optional(),
+	year: optional(z.number()),
+	season: optional(z.string()),
+	client: optional(z.string()),
+	publication: optional(z.string()),
+	format: optional(z.enum(['editorial', 'campaign', 'social', 'runway', 'event', 'film', 'model-test'])),
 
 	// Sin placeholders: si el dato no existe todavía, el campo se omite y no se pinta.
 	credits: z
 		.object({
-			photographer: z.string().optional(),
-			director: z.string().optional(),
-			muah: z.string().optional(),
-			makeup: z.string().optional(),
-			hair: z.string().optional(),
-			setDesign: z.string().optional(),
-			stylingTeam: z.string().optional(),
-			video: z.string().optional(),
-			talent: z.string().optional(),
-			talentAgency: z.string().optional(),
-			artDirection: z.string().optional(),
-			production: z.string().optional(),
-			location: z.string().optional(),
+			photographer: optional(z.string()),
+			director: optional(z.string()),
+			muah: optional(z.string()),
+			makeup: optional(z.string()),
+			hair: optional(z.string()),
+			setDesign: optional(z.string()),
+			stylingTeam: optional(z.string()),
+			video: optional(z.string()),
+			talent: optional(z.string()),
+			talentAgency: optional(z.string()),
+			artDirection: optional(z.string()),
+			production: optional(z.string()),
+			location: optional(z.string()),
 		})
 		.optional(),
 });

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -13,6 +13,22 @@ const gallerySchema = z.object({
 	aspectRatio: z.string().default('3 / 4'),
 	objectPosition: z.string().optional(),
 	images: z.array(z.string()),
+	// Fuente del orden y la visibilidad de `images`: el CMS edita este campo,
+	// no el sistema de ficheros. Ocultar una foto no la borra del disco.
+	gallery: z
+		.array(
+			z.object({
+				// Ruta pública completa (p. ej. "/assets/editorials/slug/1.webp"), la
+				// misma que acaba en el HTML. Así el CMS resuelve la miniatura sin
+				// conocer baseDir/slug/basePath del loader.
+				file: z.string(),
+				hidden: z.boolean().optional(),
+				// Portada elegida a mano. Como mucho una entrada por proyecto la trae;
+				// el loader decide qué hacer si no hay ninguna marcada.
+				cover: z.boolean().optional(),
+			}),
+		)
+		.optional(),
 	hasGallery: z.boolean().default(true),
 	order: z.number().default(0),
 

--- a/src/content/celebrities/celebrities.json
+++ b/src/content/celebrities/celebrities.json
@@ -1,7 +1,7 @@
 {
     "highlighted": [
         {
-            "id": "1",
+            "id": "miguel-herran",
             "title": "Miguel Herrán - Chaumet",
             "description": "Estilismo para evento de presentación de colección de joyería de Chaumet by Nature.",
             "img": "/assets/celebrities/miguel-herran/index.webp",
@@ -26,7 +26,7 @@
             ]
         },
         {
-            "id": "2",
+            "id": "aitana",
             "title": "Aitana - YSL",
             "description": "Estilismo para Aitana evento YSL Beauty.",
             "img": "/assets/celebrities/aitana/index.webp",
@@ -54,7 +54,7 @@
             ]
         },
         {
-            "id": "3",
+            "id": "zara",
             "title": "Zara Larsson - Amaze Festival",
             "description": "Estilismo para concierto de Zara Larsson y sus bailarinas en Amaze Festival.",
             "img": "/assets/celebrities/zara/index.webp",
@@ -102,7 +102,7 @@
             ]
         },
         {
-            "id": "4",
+            "id": "aron-piper",
             "title": "Aron Piper - YSL",
             "description": "Estilismo para Aron Piper evento YSL Beauty.",
             "img": "/assets/celebrities/aron-piper/index.webp",
@@ -127,7 +127,7 @@
             ]
         },
         {
-            "id": "5",
+            "id": "maica-supervivientes",
             "title": "Maica Benedicto - Supervivientes",
             "description": "Estilismo para Maica Benedicto en su paso por el plató de Supervivientes.",
             "img": "/assets/celebrities/maica-supervivientes/index.webp",
@@ -180,7 +180,7 @@
             ]
         },
         {
-            "id": "6",
+            "id": "tania-deniz-coachella",
             "title": "Tania Deniz - Coachella",
             "description": "Estilismo para Tania Deniz durante Coachella.",
             "img": "/assets/celebrities/tania-deniz-coachella/index.webp",
@@ -224,7 +224,7 @@
             ]
         },
         {
-            "id": "7",
+            "id": "ruth-basauri-coachella",
             "title": "Ruth Basauri - Coachella",
             "description": "Estilismo para Ruth Basauri durante Coachella.",
             "img": "/assets/celebrities/ruth-basauri-coachella/index.webp",
@@ -259,7 +259,7 @@
             ]
         },
         {
-            "id": "8",
+            "id": "maica-premios-influencers",
             "title": "Maica Benedicto - Influencers Awards",
             "description": "Estilismo para Maica Benedicto en los Influencers Awards.",
             "img": "/assets/celebrities/maica-premios-influencers/index.webp",
@@ -285,7 +285,7 @@
             ]
         },
         {
-            "id": "9",
+            "id": "alex-saint-malaga",
             "title": "Alex Saint - Festival de Málaga",
             "description": "Estilismo para Alex Saint en el Festival de Málaga.",
             "img": "/assets/celebrities/alex-saint-malaga/index.webp",

--- a/src/content/celebrities/celebrities.json
+++ b/src/content/celebrities/celebrities.json
@@ -10,7 +10,20 @@
             "order": 1,
             "role": "assistant-stylist",
             "format": "event",
-            "leadStylist": "Caterina Ospina"
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/miguel-herran/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/celebrities/miguel-herran/1.webp"
+                },
+                {
+                    "file": "/assets/celebrities/miguel-herran/2.webp"
+                }
+            ]
         },
         {
             "id": "2",
@@ -22,7 +35,23 @@
             "order": 3,
             "role": "assistant-stylist",
             "format": "event",
-            "leadStylist": "Caterina Ospina"
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/aitana/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/celebrities/aitana/1.webp"
+                },
+                {
+                    "file": "/assets/celebrities/aitana/2.webp"
+                },
+                {
+                    "file": "/assets/celebrities/aitana/3.webp"
+                }
+            ]
         },
         {
             "id": "3",
@@ -34,7 +63,43 @@
             "order": 2,
             "role": "assistant-stylist",
             "format": "event",
-            "leadStylist": "Caterina Ospina"
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/zara/1.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/2.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/3.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/4.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/celebrities/zara/5.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/6.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/7.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/8.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/9.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/10.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/11.webp"
+                }
+            ]
         },
         {
             "id": "4",
@@ -46,7 +111,20 @@
             "order": 4,
             "role": "assistant-stylist",
             "format": "event",
-            "leadStylist": "Caterina Ospina"
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/aron-piper/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/celebrities/aron-piper/1.webp"
+                },
+                {
+                    "file": "/assets/celebrities/aron-piper/2.webp"
+                }
+            ]
         },
         {
             "id": "5",
@@ -57,7 +135,49 @@
             "cardSize": "normal",
             "order": 5,
             "role": "lead-stylist",
-            "format": "event"
+            "format": "event",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/maica-supervivientes/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/celebrities/maica-supervivientes/2.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-supervivientes/3.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-supervivientes/4.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-supervivientes/5.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-supervivientes/6.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-supervivientes/7.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-supervivientes/8.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-supervivientes/9.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-supervivientes/10.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-supervivientes/11.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-supervivientes/12.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-supervivientes/13.webp"
+                }
+            ]
         },
         {
             "id": "6",
@@ -68,7 +188,40 @@
             "cardSize": "normal",
             "order": 6,
             "role": "lead-stylist",
-            "format": "event"
+            "format": "event",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/tania-deniz-coachella/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/celebrities/tania-deniz-coachella/2.webp"
+                },
+                {
+                    "file": "/assets/celebrities/tania-deniz-coachella/3.webp"
+                },
+                {
+                    "file": "/assets/celebrities/tania-deniz-coachella/4.webp"
+                },
+                {
+                    "file": "/assets/celebrities/tania-deniz-coachella/5.webp"
+                },
+                {
+                    "file": "/assets/celebrities/tania-deniz-coachella/6.webp"
+                },
+                {
+                    "file": "/assets/celebrities/tania-deniz-coachella/7.webp"
+                },
+                {
+                    "file": "/assets/celebrities/tania-deniz-coachella/8.webp"
+                },
+                {
+                    "file": "/assets/celebrities/tania-deniz-coachella/9.webp"
+                },
+                {
+                    "file": "/assets/celebrities/tania-deniz-coachella/10.webp"
+                }
+            ]
         },
         {
             "id": "7",
@@ -79,7 +232,31 @@
             "cardSize": "normal",
             "order": 7,
             "role": "lead-stylist",
-            "format": "event"
+            "format": "event",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/ruth-basauri-coachella/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/celebrities/ruth-basauri-coachella/2.webp"
+                },
+                {
+                    "file": "/assets/celebrities/ruth-basauri-coachella/3.webp"
+                },
+                {
+                    "file": "/assets/celebrities/ruth-basauri-coachella/4.webp"
+                },
+                {
+                    "file": "/assets/celebrities/ruth-basauri-coachella/5.webp"
+                },
+                {
+                    "file": "/assets/celebrities/ruth-basauri-coachella/6.webp"
+                },
+                {
+                    "file": "/assets/celebrities/ruth-basauri-coachella/7.webp"
+                }
+            ]
         },
         {
             "id": "8",
@@ -90,7 +267,22 @@
             "cardSize": "normal",
             "order": 8,
             "role": "lead-stylist",
-            "format": "event"
+            "format": "event",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/maica-premios-influencers/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/celebrities/maica-premios-influencers/2.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-premios-influencers/3.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-premios-influencers/4.webp"
+                }
+            ]
         },
         {
             "id": "9",
@@ -101,7 +293,19 @@
             "cardSize": "normal",
             "order": 9,
             "role": "lead-stylist",
-            "format": "event"
+            "format": "event",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/alex-saint-malaga/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/celebrities/alex-saint-malaga/2.webp"
+                },
+                {
+                    "file": "/assets/celebrities/alex-saint-malaga/3.webp"
+                }
+            ]
         }
     ]
 }

--- a/src/content/editorials/editorials.json
+++ b/src/content/editorials/editorials.json
@@ -1,7 +1,7 @@
 {
     "highlighted": [
         {
-            "id": "1",
+            "id": "miguel-herran",
             "title": "Numéro - Miguel Herrán",
             "description": "Editorial para Numéro Netherlands con Miguel Herrán.",
             "img": "/assets/editorials/miguel-herran/index.webp",
@@ -54,7 +54,7 @@
             ]
         },
         {
-            "id": "2",
+            "id": "vogue",
             "title": "Vogue Adria",
             "description": "Editorial para Vogue Adria.",
             "img": "/assets/editorials/vogue/index.webp",
@@ -114,7 +114,7 @@
             ]
         },
         {
-            "id": "3",
+            "id": "martina",
             "title": "Numéro - Martina Cariddi",
             "description": "Editorial para Numéro Netherlands con Martina Cariddi.",
             "img": "/assets/editorials/martina/index.webp",
@@ -174,7 +174,7 @@
             ]
         },
         {
-            "id": "4",
+            "id": "isabeli",
             "title": "Numéro - Isabeli Fontana",
             "description": "Editorial para Numéro Netherlands con Isabeli Fontana.",
             "img": "/assets/editorials/isabeli/index.webp",
@@ -241,7 +241,7 @@
             ]
         },
         {
-            "id": "5",
+            "id": "gq",
             "title": "GQ - México",
             "description": "Editorial para GQ México.",
             "img": "/assets/editorials/gq/index.webp",
@@ -272,7 +272,7 @@
             ]
         },
         {
-            "id": "6",
+            "id": "aminata",
             "title": "Mode Magazine - Aminata Sarr",
             "description": "Editorial para Mode Magazine con Aminata Sarr.",
             "img": "/assets/editorials/aminata/index.webp",
@@ -320,7 +320,7 @@
             ]
         },
         {
-            "id": "7",
+            "id": "artego-color-pop-garden",
             "title": "Artego Magazine - Color Pop Garden",
             "description": "Editorial «Color Pop Garden» para Artego Magazine.",
             "img": "/assets/editorials/artego-color-pop-garden/index.webp",
@@ -411,7 +411,7 @@
             ]
         },
         {
-            "id": "8",
+            "id": "pap-the-new-dandy",
             "title": "pap magazine - The New Dandy",
             "description": "Editorial «The New Dandy» para pap magazine.",
             "img": "/assets/editorials/pap-the-new-dandy/index.webp",
@@ -486,7 +486,7 @@
             ]
         },
         {
-            "id": "9",
+            "id": "folie-always-love",
             "title": "Folie Magazine - Always Love",
             "description": "Editorial «Always Love» para Folie Magazine.",
             "img": "/assets/editorials/folie-always-love/index.webp",
@@ -550,7 +550,7 @@
             ]
         },
         {
-            "id": "10",
+            "id": "folie-soft-tension",
             "title": "Folie Magazine - Soft Tension",
             "description": "Editorial «Soft Tension» para Folie Magazine.",
             "img": "/assets/editorials/folie-soft-tension/index.webp",
@@ -600,7 +600,7 @@
             ]
         },
         {
-            "id": "11",
+            "id": "isabel-arbos-model-test",
             "title": "Model Test - Isabel Arbós",
             "description": "Model test con Isabel Arbós.",
             "img": "/assets/editorials/isabel-arbos-model-test/index.webp",

--- a/src/content/editorials/editorials.json
+++ b/src/content/editorials/editorials.json
@@ -18,7 +18,40 @@
                 "talent": "Miguel Herrán @miguel.g.herran",
                 "production": "Saik Prod @saikprod",
                 "location": "The Palace Madrid @thepalacemadrid"
-            }
+            },
+            "gallery": [
+                {
+                    "file": "/assets/editorials/miguel-herran/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/10.webp"
+                }
+            ]
         },
         {
             "id": "2",
@@ -42,7 +75,43 @@
                 "talentAgency": "Uno Models @unomodels",
                 "production": "Saik Prod @saikprod",
                 "location": "Espacio La Candelaria @espacio_lacandelaria"
-            }
+            },
+            "gallery": [
+                {
+                    "file": "/assets/editorials/vogue/1.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/4.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/vogue/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/video-1.mp4"
+                }
+            ]
         },
         {
             "id": "3",
@@ -63,7 +132,46 @@
                 "talent": "Martina Cariddi @martinacariddi",
                 "production": "Saik Prod @saikprod",
                 "location": "Who Estudio @whoestudio"
-            }
+            },
+            "gallery": [
+                {
+                    "file": "/assets/editorials/martina/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/martina/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/11.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/12.webp"
+                }
+            ]
         },
         {
             "id": "4",
@@ -85,7 +193,52 @@
                 "talent": "Isabeli Fontana @isabelifontana",
                 "talentAgency": "The Lions Management @thelionsmgmt",
                 "production": "Saik Prod @saikprod"
-            }
+            },
+            "gallery": [
+                {
+                    "file": "/assets/editorials/isabeli/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/isabeli/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/11.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/12.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/13.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/14.webp"
+                }
+            ]
         },
         {
             "id": "5",
@@ -104,7 +257,19 @@
                 "muah": "Antonio Romero @antonioromeromakeup",
                 "talent": "Walid Fiher @w3lidd",
                 "production": "Saik Prod @saikprod"
-            }
+            },
+            "gallery": [
+                {
+                    "file": "/assets/editorials/gq/1.webp"
+                },
+                {
+                    "file": "/assets/editorials/gq/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/gq/3.webp",
+                    "cover": true
+                }
+            ]
         },
         {
             "id": "6",
@@ -122,7 +287,37 @@
                 "makeup": "@nermosu_",
                 "hair": "@f0urt4zz",
                 "talent": "Aminata Sarr @aminata.sr"
-            }
+            },
+            "gallery": [
+                {
+                    "file": "/assets/editorials/aminata/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/aminata/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/aminata/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/aminata/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/aminata/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/aminata/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/aminata/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/aminata/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/aminata/9.webp"
+                }
+            ]
         },
         {
             "id": "7",
@@ -138,7 +333,82 @@
                 "photographer": "Alex Guerra @aleguerrax",
                 "muah": "Diego Vitaller @muagami_beauty",
                 "talent": "Kamila Iskairova @iskairova_"
-            }
+            },
+            "gallery": [
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/11.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/12.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/13.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/14.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/15.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/16.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/17.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/18.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/19.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/20.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/21.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/22.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/23.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/24.webp"
+                }
+            ]
         },
         {
             "id": "8",
@@ -156,7 +426,64 @@
                 "video": "Camilo Andrés @camilo5p",
                 "talent": "Álvaro García Narváez @alvarogarcianarvaez",
                 "talentAgency": "The Road Models @theroadmodels"
-            }
+            },
+            "gallery": [
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/11.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/12.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/13.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/14.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/15.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/16.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/17.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/18.webp"
+                }
+            ]
         },
         {
             "id": "9",
@@ -172,7 +499,55 @@
                 "photographer": "Leticia Díaz de la Morena @leticiadiazdelamorena",
                 "muah": "Diego Vitaller @muagami_beauty",
                 "talent": "Charlotte Eva @charlotteeeva"
-            }
+            },
+            "gallery": [
+                {
+                    "file": "/assets/editorials/folie-always-love/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/11.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/12.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/13.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/14.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/15.webp"
+                }
+            ]
         },
         {
             "id": "10",
@@ -189,7 +564,40 @@
                 "muah": "Diego Vitaller @muagami_beauty",
                 "talent": "Luca Darblade @luca_darblade",
                 "talentAgency": "Wanted Agency @wantedagency"
-            }
+            },
+            "gallery": [
+                {
+                    "file": "/assets/editorials/folie-soft-tension/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/10.webp"
+                }
+            ]
         },
         {
             "id": "11",
@@ -206,7 +614,94 @@
                 "muah": "Diego Vitaller @muagami_beauty",
                 "talent": "Isabel Arbós @isabel_arbos",
                 "talentAgency": "Six Management @sixmanagement.es"
-            }
+            },
+            "gallery": [
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/11.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/12.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/13.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/14.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/15.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/16.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/17.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/18.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/19.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/20.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/21.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/22.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/23.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/24.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/25.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/26.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/27.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/28.webp"
+                }
+            ]
         }
     ]
 }

--- a/src/content/films/films.json
+++ b/src/content/films/films.json
@@ -8,7 +8,25 @@
             "img_alt": "La Mitad de Ana",
             "cardSize": "normal",
             "order": 1,
-            "role": "assistant-stylist"
+            "role": "assistant-stylist",
+            "gallery": [
+                {
+                    "file": "/assets/films/la-mitad-de-ana/1.webp"
+                },
+                {
+                    "file": "/assets/films/la-mitad-de-ana/2.webp"
+                },
+                {
+                    "file": "/assets/films/la-mitad-de-ana/3.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/films/la-mitad-de-ana/4.webp"
+                },
+                {
+                    "file": "/assets/films/la-mitad-de-ana/5.webp"
+                }
+            ]
         }
     ]
 }

--- a/src/content/publicity/publicity.json
+++ b/src/content/publicity/publicity.json
@@ -10,7 +10,40 @@
             "order": 1,
             "role": "assistant-stylist",
             "format": "campaign",
-            "leadStylist": "Caterina Ospina"
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/publicity/alaniz-maria-pombo/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/alaniz-maria-pombo/2.webp"
+                },
+                {
+                    "file": "/assets/publicity/alaniz-maria-pombo/3.webp"
+                },
+                {
+                    "file": "/assets/publicity/alaniz-maria-pombo/4.webp"
+                },
+                {
+                    "file": "/assets/publicity/alaniz-maria-pombo/5.webp"
+                },
+                {
+                    "file": "/assets/publicity/alaniz-maria-pombo/6.webp"
+                },
+                {
+                    "file": "/assets/publicity/alaniz-maria-pombo/7.webp"
+                },
+                {
+                    "file": "/assets/publicity/alaniz-maria-pombo/video-1.mp4"
+                },
+                {
+                    "file": "/assets/publicity/alaniz-maria-pombo/video-2.mp4"
+                },
+                {
+                    "file": "/assets/publicity/alaniz-maria-pombo/video-3.mp4"
+                }
+            ]
         },
         {
             "id": "bruno-magli",
@@ -21,7 +54,40 @@
             "cardSize": "normal",
             "order": 2,
             "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina"
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/publicity/bruno-magli/1.webp"
+                },
+                {
+                    "file": "/assets/publicity/bruno-magli/2.webp"
+                },
+                {
+                    "file": "/assets/publicity/bruno-magli/3.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/bruno-magli/4.webp"
+                },
+                {
+                    "file": "/assets/publicity/bruno-magli/5.webp"
+                },
+                {
+                    "file": "/assets/publicity/bruno-magli/6.webp"
+                },
+                {
+                    "file": "/assets/publicity/bruno-magli/video-1.mp4"
+                },
+                {
+                    "file": "/assets/publicity/bruno-magli/video-2.mp4"
+                },
+                {
+                    "file": "/assets/publicity/bruno-magli/video-3.mp4"
+                },
+                {
+                    "file": "/assets/publicity/bruno-magli/video-4.mp4"
+                }
+            ]
         },
         {
             "id": "prime-video-zara-larsson",
@@ -33,7 +99,22 @@
             "order": 3,
             "role": "assistant-stylist",
             "leadStylist": "Caterina Ospina",
-            "featured": true
+            "featured": true,
+            "gallery": [
+                {
+                    "file": "/assets/publicity/prime-video-zara-larsson/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/prime-video-zara-larsson/2.webp"
+                },
+                {
+                    "file": "/assets/publicity/prime-video-zara-larsson/3.webp"
+                },
+                {
+                    "file": "/assets/publicity/prime-video-zara-larsson/4.webp"
+                }
+            ]
         },
         {
             "id": "ysl-aitana",
@@ -43,7 +124,17 @@
             "cardSize": "normal",
             "order": 4,
             "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina"
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/publicity/ysl-aitana/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/ysl-aitana/video-1.mp4"
+                }
+            ]
         },
         {
             "id": "agatha-paris-maria-pombo",
@@ -54,7 +145,22 @@
             "cardSize": "normal",
             "order": 5,
             "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina"
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/publicity/agatha-paris-maria-pombo/1.webp"
+                },
+                {
+                    "file": "/assets/publicity/agatha-paris-maria-pombo/2.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/agatha-paris-maria-pombo/video-1.mp4"
+                },
+                {
+                    "file": "/assets/publicity/agatha-paris-maria-pombo/video-2.mp4"
+                }
+            ]
         },
         {
             "id": "gdh-jesus-de-paula",
@@ -65,7 +171,26 @@
             "cardSize": "normal",
             "order": 6,
             "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina"
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/publicity/gdh-jesus-de-paula/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/gdh-jesus-de-paula/video-1.mp4"
+                },
+                {
+                    "file": "/assets/publicity/gdh-jesus-de-paula/video-2.mp4"
+                },
+                {
+                    "file": "/assets/publicity/gdh-jesus-de-paula/video-3.mp4"
+                },
+                {
+                    "file": "/assets/publicity/gdh-jesus-de-paula/video-4.mp4"
+                }
+            ]
         },
         {
             "id": "kerastase",
@@ -75,7 +200,17 @@
             "cardSize": "normal",
             "order": 7,
             "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina"
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/publicity/kerastase/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/kerastase/video-1.mp4"
+                }
+            ]
         },
         {
             "id": "kerastase-lola-lolita",
@@ -85,7 +220,17 @@
             "cardSize": "normal",
             "order": 8,
             "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina"
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/publicity/kerastase-lola-lolita/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/kerastase-lola-lolita/kerastase-lola-lolita.mp4"
+                }
+            ]
         },
         {
             "id": "kerastase-nicole-wallace",
@@ -95,7 +240,17 @@
             "cardSize": "normal",
             "order": 9,
             "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina"
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/publicity/kerastase-nicole-wallace/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/kerastase-nicole-wallace/kerastase-nicole-wallace.mp4"
+                }
+            ]
         },
         {
             "id": "redken-marina-reche",
@@ -105,7 +260,17 @@
             "cardSize": "normal",
             "order": 10,
             "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina"
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/publicity/redken-marina-reche/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/redken-marina-reche/video-1.mp4"
+                }
+            ]
         },
         {
             "id": "vogue-spain-maria-pombo",
@@ -115,7 +280,17 @@
             "cardSize": "normal",
             "order": 11,
             "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina"
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/publicity/vogue-spain-maria-pombo/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/vogue-spain-maria-pombo/vogue-spain-maria-pombo.mp4"
+                }
+            ]
         }
     ]
 }

--- a/src/content/runway/runway.json
+++ b/src/content/runway/runway.json
@@ -8,7 +8,38 @@
             "img_alt": "Desfile Primavera/Verano 26 Rosé Noir Claro Couture",
             "cardSize": "normal",
             "order": 1,
-            "role": "lead-stylist"
+            "role": "lead-stylist",
+            "gallery": [
+                {
+                    "file": "/assets/runway/claro-couture/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/runway/claro-couture/1.webp"
+                },
+                {
+                    "file": "/assets/runway/claro-couture/2.webp"
+                },
+                {
+                    "file": "/assets/runway/claro-couture/video-1.mp4"
+                },
+                {
+                    "file": "/assets/runway/claro-couture/video-2.mp4"
+                },
+                {
+                    "file": "/assets/runway/claro-couture/video-3.mp4"
+                },
+                {
+                    "file": "/assets/runway/claro-couture/video-4.mp4"
+                },
+                {
+                    "file": "/assets/runway/claro-couture/video-5.mp4"
+                },
+                {
+                    "file": "/assets/runway/claro-couture/video-6.mp4"
+                }
+            ]
         },
         {
             "id": "angel-schlesser-25-antonte",
@@ -18,7 +49,29 @@
             "img_alt": "Desfile Ángel Schlesser Primavera/Verano 25 Antonte",
             "cardSize": "normal",
             "order": 2,
-            "role": "wardrobe-assistant"
+            "role": "wardrobe-assistant",
+            "gallery": [
+                {
+                    "file": "/assets/runway/angel-schlesser-2025/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2025/1.webp"
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2025/video-1.mp4"
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2025/video-2.mp4"
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2025/video-3.mp4"
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2025/video-4.mp4"
+                }
+            ]
         },
         {
             "id": "angel-schlesser-24-intersticio",
@@ -28,7 +81,25 @@
             "img_alt": "Colección Ángel Schlesser Primavera/Verano 24 Intersticio",
             "cardSize": "normal",
             "order": 3,
-            "role": "wardrobe-assistant"
+            "role": "wardrobe-assistant",
+            "gallery": [
+                {
+                    "file": "/assets/runway/angel-schlesser-2024/1.webp"
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2024/2.webp"
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2024/3.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2024/video-1.mp4"
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2024/video-2.mp4"
+                }
+            ]
         },
         {
             "id": "angel-schlesser-23-femme",
@@ -38,7 +109,25 @@
             "img_alt": "Desfile Ángel Schlesser",
             "cardSize": "normal",
             "order": 4,
-            "role": "wardrobe-assistant"
+            "role": "wardrobe-assistant",
+            "gallery": [
+                {
+                    "file": "/assets/runway/angel-schlesser-2023/4.webp"
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2023/6.webp"
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2023/7.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2023/8.webp"
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2023/video-1.mp4"
+                }
+            ]
         }
     ]
 }

--- a/src/content/runway/runway.json
+++ b/src/content/runway/runway.json
@@ -42,7 +42,7 @@
             ]
         },
         {
-            "id": "angel-schlesser-25-antonte",
+            "id": "angel-schlesser-2025",
             "title": "Desfile Primavera/Verano 25 Antonte - Ángel Schlesser",
             "description": "Desfile Primavera/Verano 25 «Antonte» de Ángel Schlesser en Mercedes-Benz Fashion Week Madrid.",
             "img": "/assets/runway/angel-schlesser-2025/1.webp",
@@ -74,7 +74,7 @@
             ]
         },
         {
-            "id": "angel-schlesser-24-intersticio",
+            "id": "angel-schlesser-2024",
             "title": "Colección Primavera/Verano 24 Intersticio - Ángel Schlesser",
             "description": "Colección Primavera/Verano 24 «Intersticio» de Ángel Schlesser en Mercedes-Benz Fashion Week Madrid.",
             "img": "/assets/runway/angel-schlesser-2024/1.webp",
@@ -102,7 +102,7 @@
             ]
         },
         {
-            "id": "angel-schlesser-23-femme",
+            "id": "angel-schlesser-2023",
             "title": "Otoño/Invierno 23.Femme - Ángel Schlesser",
             "description": "Desfile Otoño/Invierno 23.Femme de Ángel Schlesser en el programa OFF de Mercedes-Benz Fashion Week Madrid, en el Espacio Larra.",
             "img": "/assets/runway/angel-schlesser-2023/4.webp",

--- a/src/loaders/gallery-loader.ts
+++ b/src/loaders/gallery-loader.ts
@@ -9,6 +9,12 @@ interface GalleryConfig {
   basePath?: string;
 }
 
+interface GalleryMediaItem {
+  file: string;
+  hidden?: boolean;
+  cover?: boolean;
+}
+
 interface GalleryEntry {
   id: string;
   title: string;
@@ -20,6 +26,7 @@ interface GalleryEntry {
   aspectRatio: string;
   objectPosition?: string;
   images: string[];
+  gallery?: GalleryMediaItem[];
   hasGallery: boolean;
   order: number;
   featured?: boolean;
@@ -62,28 +69,39 @@ export function createGalleryLoader(config: GalleryConfig) {
         return basePath ? `${basePath}${relativePath}` : relativePath;
       };
 
-      // Obtener todas las imágenes y videos excepto index.*
       const allFiles = readdirSync(imagesDir);
-      const images = allFiles
-        .filter(f => /\.(jpg|jpeg|png|webp|mp4|webm|mov)$/i.test(f) && !f.startsWith('index.'))
-        // Orden natural (1, 2, ..., 10, 11) en vez de lexicográfico ('1', '10', '11', '2', ...):
-        // las galerías de más de 9 fotos numeradas como 1.webp, 2.webp... quedarían desordenadas
-        // con un .sort() por defecto, que compara los nombres carácter a carácter.
-        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
-        .map(f => getPath(f));
-
-      // Buscar imagen index
-      const indexImage = allFiles.find(f => f.startsWith('index.'));
-      const img = indexImage ? getPath(indexImage) : images[0];
-
-      // Buscar video
-      const videoFile = allFiles.find(f => /\.(mp4|webm|mov)$/i.test(f));
-      const video = videoFile ? getPath(videoFile) : undefined;
 
       // Buscar info en el JSON
       const info = Array.isArray(jsonData)
         ? jsonData.find(item => item.id === slug || item.img?.includes(slug))
         : jsonData[slug]?.[0];
+
+      // La lista de fotos es un dato explícito del JSON (orden + visibilidad),
+      // pensado para que un CMS la edite sin tocar el sistema de ficheros.
+      // Si un proyecto no la tiene todavía, se sigue leyendo el directorio.
+      // `file` ya guarda la ruta pública completa (la resuelve el CMS al
+      // guardar), así que aquí se usa tal cual sin volver a anteponer nada.
+      const gallery: GalleryMediaItem[] | undefined = info?.gallery;
+      const images = gallery
+        ? gallery.filter(item => !item.hidden).map(item => item.file)
+        : allFiles
+            .filter(f => /\.(jpg|jpeg|png|webp|mp4|webm|mov)$/i.test(f) && !f.startsWith('index.'))
+            // Orden natural (1, 2, ..., 10, 11) en vez de lexicográfico ('1', '10', '11', '2', ...):
+            // las galerías de más de 9 fotos numeradas como 1.webp, 2.webp... quedarían desordenadas
+            // con un .sort() por defecto, que compara los nombres carácter a carácter.
+            .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+            .map(f => getPath(f));
+
+      // La portada es un dato explícito (`cover: true` en `gallery`), buscado en
+      // toda la lista y no solo en las visibles: ocultar una foto no le quita
+      // el derecho a seguir siendo portada. Los 36 proyectos la tienen marcada;
+      // si alguno nuevo no la marca, cae a la primera imagen visible.
+      const coverItem = gallery?.find(item => item.cover);
+      const img = coverItem ? coverItem.file : images[0];
+
+      // Buscar video
+      const videoFile = allFiles.find(f => /\.(mp4|webm|mov)$/i.test(f));
+      const video = videoFile ? getPath(videoFile) : undefined;
 
       // `> 0` y no `> 1`: un proyecto de un solo vídeo también tiene ficha, que
       // es donde viven los créditos. Con `> 1` esas seis tarjetas no enlazaban.
@@ -100,6 +118,7 @@ export function createGalleryLoader(config: GalleryConfig) {
         aspectRatio: info?.aspectRatio || '3 / 4',
         objectPosition: info?.objectPosition,
         images,
+        gallery,
         hasGallery,
         order: info?.order || 0,
         featured: info?.featured,

--- a/src/loaders/gallery-loader.ts
+++ b/src/loaders/gallery-loader.ts
@@ -1,5 +1,4 @@
 import { readdirSync, existsSync, readFileSync } from 'fs';
-import { join } from 'path';
 
 interface GalleryConfig {
   baseDir: string;
@@ -21,7 +20,6 @@ interface GalleryEntry {
   description: string;
   img: string;
   img_alt: string;
-  video?: string;
   cardSize: string;
   aspectRatio: string;
   objectPosition?: string;
@@ -44,7 +42,7 @@ interface GalleryEntry {
 
 export function createGalleryLoader(config: GalleryConfig) {
   return async (): Promise<GalleryEntry[]> => {
-    const { baseDir, jsonPath, jsonKey, hasSubfolders = true, basePath = '' } = config;
+    const { baseDir, jsonPath, jsonKey } = config;
 
     // Leer datos del JSON
     const jsonContent = readFileSync(jsonPath, 'utf-8');
@@ -59,80 +57,78 @@ export function createGalleryLoader(config: GalleryConfig) {
     const dirs = readdirSync(baseDir, { withFileTypes: true })
       .filter(d => d.isDirectory());
 
-    return dirs.map(dir => {
-      const slug = dir.name;
-      const imagesDir = join(baseDir, slug);
+    return dirs
+      .map(dir => {
+        const slug = dir.name;
 
-      // Helper to prepend base path
-      const getPath = (path: string) => {
-        const relativePath = `/assets/${baseDir.split('/assets/')[1]}/${slug}/${path}`;
-        return basePath ? `${basePath}${relativePath}` : relativePath;
-      };
+        // Emparejamiento exacto: `id` ya es el slug del directorio (migrado
+        // desde los antiguos "1".."11"), nada de `includes` sobre `img`, que
+        // era ambiguo entre proyectos con slugs que se contienen unos a otros
+        // (p. ej. "kerastase" en "kerastase-lola-lolita").
+        const info = Array.isArray(jsonData)
+          ? jsonData.find(item => item.id === slug)
+          : jsonData[slug]?.[0];
 
-      const allFiles = readdirSync(imagesDir);
+        // Borrar la fila del CMS saca el proyecto del portfolio, pero el
+        // directorio de fotos se queda en disco. Sin esta comprobación el
+        // loader fabricaría una entrada sin `role` (obligatorio) y el build
+        // moriría en la validación del esquema.
+        if (!info) {
+          console.warn(
+            `[gallery-loader] "${slug}" en ${baseDir} no tiene entrada en ${jsonPath}: se omite del portfolio.`,
+          );
+          return null;
+        }
 
-      // Buscar info en el JSON
-      const info = Array.isArray(jsonData)
-        ? jsonData.find(item => item.id === slug || item.img?.includes(slug))
-        : jsonData[slug]?.[0];
+        // La lista de fotos es la única fuente de verdad de orden y visibilidad,
+        // pensada para que el CMS la edite sin tocar el sistema de ficheros. Ya
+        // no hay camino de respaldo que lea el directorio: daba un resultado
+        // distinto (resucitaba fotos ocultas, excluía `index.*` que en 12
+        // proyectos era la portada, y reordenaba por nombre), y un respaldo que
+        // publica otro portfolio no es un respaldo.
+        const gallery: GalleryMediaItem[] | undefined = info.gallery;
+        if (!gallery) {
+          console.warn(`[gallery-loader] "${slug}" no tiene "gallery" en ${jsonPath}: no se publican fotos.`);
+        }
+        const images = gallery ? gallery.filter(item => !item.hidden).map(item => item.file) : [];
 
-      // La lista de fotos es un dato explícito del JSON (orden + visibilidad),
-      // pensado para que un CMS la edite sin tocar el sistema de ficheros.
-      // Si un proyecto no la tiene todavía, se sigue leyendo el directorio.
-      // `file` ya guarda la ruta pública completa (la resuelve el CMS al
-      // guardar), así que aquí se usa tal cual sin volver a anteponer nada.
-      const gallery: GalleryMediaItem[] | undefined = info?.gallery;
-      const images = gallery
-        ? gallery.filter(item => !item.hidden).map(item => item.file)
-        : allFiles
-            .filter(f => /\.(jpg|jpeg|png|webp|mp4|webm|mov)$/i.test(f) && !f.startsWith('index.'))
-            // Orden natural (1, 2, ..., 10, 11) en vez de lexicográfico ('1', '10', '11', '2', ...):
-            // las galerías de más de 9 fotos numeradas como 1.webp, 2.webp... quedarían desordenadas
-            // con un .sort() por defecto, que compara los nombres carácter a carácter.
-            .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
-            .map(f => getPath(f));
+        // La portada es un dato explícito (`cover: true` en `gallery`), buscado en
+        // toda la lista y no solo en las visibles: ocultar una foto no le quita
+        // el derecho a seguir siendo portada. Los 36 proyectos la tienen marcada;
+        // si alguno nuevo no la marca, cae a la primera imagen visible.
+        const coverItem = gallery?.find(item => item.cover);
+        const img = coverItem ? coverItem.file : images[0];
 
-      // La portada es un dato explícito (`cover: true` en `gallery`), buscado en
-      // toda la lista y no solo en las visibles: ocultar una foto no le quita
-      // el derecho a seguir siendo portada. Los 36 proyectos la tienen marcada;
-      // si alguno nuevo no la marca, cae a la primera imagen visible.
-      const coverItem = gallery?.find(item => item.cover);
-      const img = coverItem ? coverItem.file : images[0];
+        // `> 0` y no `> 1`: un proyecto de un solo vídeo también tiene ficha, que
+        // es donde viven los créditos. Con `> 1` esas seis tarjetas no enlazaban.
+        const hasGallery = images.length > 0;
 
-      // Buscar video
-      const videoFile = allFiles.find(f => /\.(mp4|webm|mov)$/i.test(f));
-      const video = videoFile ? getPath(videoFile) : undefined;
-
-      // `> 0` y no `> 1`: un proyecto de un solo vídeo también tiene ficha, que
-      // es donde viven los créditos. Con `> 1` esas seis tarjetas no enlazaban.
-      const hasGallery = images.length > 0;
-
-      return {
-        id: slug,
-        title: info?.title || slug,
-        description: info?.description || '',
-        img: img || '',
-        img_alt: info?.img_alt || info?.title || slug,
-        video,
-        cardSize: info?.cardSize || 'normal',
-        aspectRatio: info?.aspectRatio || '3 / 4',
-        objectPosition: info?.objectPosition,
-        images,
-        gallery,
-        hasGallery,
-        order: info?.order || 0,
-        featured: info?.featured,
-        pin: info?.pin,
-        role: info?.role,
-        roleDetail: info?.roleDetail,
-        leadStylist: info?.leadStylist,
-        year: info?.year,
-        season: info?.season,
-        client: info?.client,
-        publication: info?.publication,
-        format: info?.format,
-        credits: info?.credits,
-      };
-    }).filter(entry => entry.img || entry.video);
+        return {
+          id: slug,
+          title: info.title || slug,
+          description: info.description || '',
+          img: img || '',
+          img_alt: info.img_alt || info.title || slug,
+          cardSize: info.cardSize || 'normal',
+          aspectRatio: info.aspectRatio || '3 / 4',
+          objectPosition: info.objectPosition,
+          images,
+          gallery,
+          hasGallery,
+          order: info.order || 0,
+          featured: info.featured,
+          pin: info.pin,
+          role: info.role,
+          roleDetail: info.roleDetail,
+          leadStylist: info.leadStylist,
+          year: info.year,
+          season: info.season,
+          client: info.client,
+          publication: info.publication,
+          format: info.format,
+          credits: info.credits,
+        };
+      })
+      .filter((entry): entry is GalleryEntry => entry !== null && Boolean(entry.img));
   };
 }


### PR DESCRIPTION
Luisa quiere reorganizar el portfolio a su ritmo: cambiar el orden, elegir portadas y quitar fotos de la vista. Esto prepara el contenido para que pueda hacerlo sin tocar código, y deja montada la página de edición en `/admin`.

## El obstáculo no era la herramienta, era el dato

El orden de las fotos **se deducía del nombre del fichero**, así que reordenar dos fotos significaba renombrarlas en cadena. Y la portada era un fichero `index.webp` que había que **copiar encima de otro**. Nada de eso lo puede hacer un CMS, que edita datos y no ficheros.

Ahora cada proyecto lleva su lista:

```json
{ "file": "/assets/editorials/artego-color-pop-garden/1.webp", "cover": true }
```

- **El orden del array es el orden de la galería.**
- **`cover`** marca la portada.
- **`hidden`** saca una foto del portfolio **sin borrarla del disco**, así que es reversible.
- La ruta va completa porque con solo el nombre el CMS no sabe dónde está la imagen y la pinta como texto. Se probó: Luisa habría estado arrastrando nombres de fichero a ciegas.

## Verificado en cada paso

La migración fue en tres pasos, cada uno comprobado contra las 117 páginas generadas:

| Paso | Resultado |
|---|---|
| Lista de medios al JSON | 117/117 huellas idénticas |
| Portada como dato | Solo cambian las URL de los 12 listados; las **108 imágenes comprobadas por hash**, cambia la dirección y no la foto |
| Rutas completas | 117/117 huellas idénticas |

## Las 12 portadas huérfanas

En 12 proyectos la portada **no era ninguna de sus fotos**, sino una imagen propia que solo existía como `index.webp`. Tres de ellos (Kérastase, YSL, Redken) ni siquiera tienen fotos, solo vídeo.

Esa imagen entra en la lista marcada como oculta y como portada, así que la regla queda única para los 36 y el `index.*` deja de mandar en todo el sitio.

## La configuración, y un detalle que casi cuesta caro

Declara **los catorce campos a propósito**: en una colección de este tipo, un campo que exista en el JSON y no esté declarado **se pierde al guardar**. Sin eso, la primera vez que Luisa tocara algo habríamos perdido los créditos que acabamos de meter.

El **rol, la estilista principal y los créditos** van ocultos: se conservan intactos pero no se editan desde el CMS. La atribución se decide fuera.

`publish_mode: editorial_workflow`: cada cambio abre una propuesta en vez de publicar directo. Además de dar un filtro de revisión, evita que quince ajustes seguidos disparen quince despliegues de diez minutos.

## Lo que falta

La autenticación, que necesita credenciales de David. Los pasos están en `docs/admin-puesta-en-marcha.md`.

**Subir fotos queda fuera a propósito**: las imágenes pasan por el script que las convierte a webp de 2048px, y una foto cruda de cámara dispararía el peso del sitio.

## Comprobado

`pnpm build` 117 páginas · `pnpm check:links` OK · `pnpm cv` en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQ3fpT2Ck2fq8HqqJ5vtr