### PR TITLE
Cambios de Luisa y pantalla en cuadrícula para ordenar fotos

### DIFF
--- a/public/admin/ordenar/index.html
+++ b/public/admin/ordenar/index.html
@@ -1,0 +1,390 @@
+<!doctype html>
+<html lang="es">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="robots" content="noindex, nofollow" />
+		<title>Ordenar fotos</title>
+		<style>
+			:root {
+				color-scheme: dark;
+				--fondo: #0d1017;
+				--panel: #161a25;
+				--borde: #2a3040;
+				--texto: #e8eaf0;
+				--suave: #99a0b0;
+				--acento: #7cff6b;
+				--aviso: #ffd166;
+				--error: #ff8a8a;
+			}
+			* { box-sizing: border-box; }
+			body {
+				margin: 0;
+				background: var(--fondo);
+				color: var(--texto);
+				font: 15px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+			}
+			header {
+				position: sticky;
+				top: 0;
+				z-index: 10;
+				display: flex;
+				flex-wrap: wrap;
+				gap: 0.75rem 1rem;
+				align-items: center;
+				padding: 0.9rem 1.5rem;
+				background: var(--panel);
+				border-bottom: 1px solid var(--borde);
+			}
+			h1 { font-size: 1rem; margin: 0; font-weight: 600; }
+			select, input, button { font: inherit; }
+			select, input[type="password"] {
+				background: var(--fondo);
+				color: var(--texto);
+				border: 1px solid var(--borde);
+				border-radius: 8px;
+				padding: 0.5rem 0.75rem;
+			}
+			select { max-width: 24rem; }
+			.contador { color: var(--suave); font-size: 0.9rem; }
+			.derecha { margin-left: auto; display: flex; align-items: center; gap: 0.75rem; }
+			.estado { font-size: 0.88rem; color: var(--suave); }
+			.estado.ok { color: var(--acento); }
+			.estado.mal { color: var(--error); }
+			.guardar {
+				background: var(--acento);
+				color: #06210a;
+				border: 0;
+				border-radius: 8px;
+				padding: 0.55rem 1.1rem;
+				font-weight: 700;
+				cursor: pointer;
+			}
+			.guardar[disabled] { opacity: 0.4; cursor: default; }
+			main { padding: 1.5rem; }
+			.rejilla {
+				display: grid;
+				grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+				gap: 1rem;
+			}
+			.tarjeta {
+				position: relative;
+				border: 1px solid var(--borde);
+				border-radius: 10px;
+				overflow: hidden;
+				background: var(--panel);
+				cursor: grab;
+				outline: 2px solid transparent;
+				transition: outline-color 0.12s, opacity 0.12s;
+			}
+			.tarjeta:active { cursor: grabbing; }
+			.tarjeta img {
+				display: block;
+				width: 100%;
+				aspect-ratio: 3 / 4;
+				object-fit: cover;
+				pointer-events: none;
+			}
+			.tarjeta.arrastrando { opacity: 0.35; }
+			.tarjeta.destino { outline-color: var(--acento); }
+			.tarjeta.oculta img { opacity: 0.25; filter: grayscale(1); }
+			.numero {
+				position: absolute; top: 6px; left: 6px;
+				background: rgba(0, 0, 0, 0.7);
+				border-radius: 6px; padding: 1px 7px;
+				font-size: 0.8rem; font-variant-numeric: tabular-nums;
+			}
+			.marca {
+				position: absolute; top: 6px; right: 6px;
+				background: var(--acento); color: #06210a;
+				border-radius: 6px; padding: 1px 7px;
+				font-size: 0.72rem; font-weight: 700; letter-spacing: 0.06em;
+			}
+			.acciones { display: flex; border-top: 1px solid var(--borde); }
+			.acciones button {
+				flex: 1; background: none; border: 0;
+				border-right: 1px solid var(--borde);
+				color: var(--suave); font-size: 0.82rem;
+				padding: 0.45rem 0; cursor: pointer;
+			}
+			.acciones button:last-child { border-right: 0; }
+			.acciones button:hover { background: #1e2333; color: var(--texto); }
+			.acciones button.activo { color: var(--acento); font-weight: 600; }
+			.entrada {
+				max-width: 34rem;
+				margin: 6rem auto;
+				padding: 2rem;
+				background: var(--panel);
+				border: 1px solid var(--borde);
+				border-radius: 12px;
+			}
+			.entrada h2 { margin-top: 0; font-size: 1.1rem; }
+			.entrada p { color: var(--suave); font-size: 0.92rem; }
+			.entrada input { width: 100%; margin: 0.75rem 0; }
+			.oculto { display: none; }
+		</style>
+	</head>
+	<body>
+		<section class="entrada" id="entrada">
+			<h2>Ordenar fotos</h2>
+			<p>
+				Pega aquí tu token de GitHub. Se guarda solo en este navegador y no se
+				envía a ningún sitio que no sea GitHub.
+			</p>
+			<input type="password" id="token" placeholder="ghp_..." autocomplete="off" />
+			<button class="guardar" id="entrar">Entrar</button>
+			<p class="estado mal" id="errorEntrada"></p>
+		</section>
+
+		<div id="app" class="oculto">
+			<header>
+				<h1>Ordenar fotos</h1>
+				<select id="proyecto"></select>
+				<span class="contador" id="contador"></span>
+				<span class="derecha">
+					<span class="estado" id="estado"></span>
+					<button class="guardar" id="guardar" disabled>Guardar</button>
+				</span>
+			</header>
+			<main><div class="rejilla" id="rejilla"></div></main>
+		</div>
+
+		<script type="module">
+			const REPO = 'davidarce/portfolio-luisa-benitez';
+			const RAMA = 'contenido';
+			const COLECCIONES = [
+				['Editoriales', 'src/content/editorials/editorials.json'],
+				['Campañas', 'src/content/publicity/publicity.json'],
+				['Celebridades y eventos', 'src/content/celebrities/celebrities.json'],
+				['Runway', 'src/content/runway/runway.json'],
+				['Cine', 'src/content/films/films.json'],
+			];
+
+			const $ = (id) => document.getElementById(id);
+			let token = localStorage.getItem('token-ordenar') || '';
+			// Por fichero: { datos, sha }. El sha es la versión que leímos de GitHub;
+			// si alguien guarda antes que nosotros, GitHub rechaza el envío y avisamos
+			// en vez de pisar su trabajo.
+			const ficheros = new Map();
+			let actual = null;
+			let sucio = false;
+			let arrastrada = null;
+
+			async function api(ruta, opciones = {}) {
+				const r = await fetch(`https://api.github.com/repos/${REPO}/${ruta}`, {
+					...opciones,
+					headers: {
+						Authorization: `Bearer ${token}`,
+						Accept: 'application/vnd.github+json',
+						...(opciones.headers || {}),
+					},
+				});
+				if (!r.ok) throw new Error(`${r.status} ${(await r.text()).slice(0, 160)}`);
+				return r.json();
+			}
+
+			const deBase64 = (b64) => new TextDecoder().decode(Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)));
+			const aBase64 = (txt) => btoa(String.fromCharCode(...new TextEncoder().encode(txt)));
+
+			async function cargar() {
+				ficheros.clear();
+				for (const [etiqueta, ruta] of COLECCIONES) {
+					const r = await api(`contents/${ruta}?ref=${RAMA}`);
+					ficheros.set(ruta, {
+						etiqueta,
+						sha: r.sha,
+						datos: JSON.parse(deBase64(r.content.replace(/\n/g, ''))),
+					});
+				}
+			}
+
+			function proyectos() {
+				const salida = [];
+				for (const [ruta, f] of ficheros) {
+					for (const p of f.datos.highlighted) salida.push({ ruta, etiqueta: f.etiqueta, p });
+				}
+				return salida;
+			}
+
+			function montarSelector() {
+				const s = $('proyecto');
+				s.replaceChildren();
+				let grupo = null;
+				for (const { ruta, etiqueta, p } of proyectos()) {
+					if (!grupo || grupo.label !== etiqueta) {
+						grupo = document.createElement('optgroup');
+						grupo.label = etiqueta;
+						s.append(grupo);
+					}
+					const o = document.createElement('option');
+					o.value = `${ruta}::${p.id}`;
+					o.textContent = `${p.title} (${(p.gallery || []).length})`;
+					grupo.append(o);
+				}
+			}
+
+			function elegir(valor) {
+				const [ruta, id] = valor.split('::');
+				actual = { ruta, p: ficheros.get(ruta).datos.highlighted.find((x) => x.id === id) };
+				pintar();
+			}
+
+			function pintar() {
+				const fotos = actual.p.gallery || [];
+				$('rejilla').replaceChildren();
+				fotos.forEach((foto, i) => {
+					const t = document.createElement('div');
+					t.className = 'tarjeta' + (foto.hidden ? ' oculta' : '');
+					t.draggable = true;
+					t.dataset.i = i;
+					t.innerHTML = `
+						<span class="numero">${i + 1}</span>
+						${foto.cover ? '<span class="marca">PORTADA</span>' : ''}
+						<img src="${foto.file}" alt="" loading="lazy">
+						<div class="acciones">
+							<button data-accion="ocultar" class="${foto.hidden ? 'activo' : ''}">${foto.hidden ? 'Oculta' : 'Ocultar'}</button>
+							<button data-accion="portada" class="${foto.cover ? 'activo' : ''}">Portada</button>
+						</div>`;
+					$('rejilla').append(t);
+				});
+				$('contador').textContent = `${fotos.filter((f) => !f.hidden).length} visibles de ${fotos.length}`;
+			}
+
+			function marcarSucio() {
+				sucio = true;
+				$('guardar').disabled = false;
+				$('estado').textContent = 'sin guardar';
+				$('estado').className = 'estado';
+			}
+
+			$('rejilla').addEventListener('click', (e) => {
+				const btn = e.target.closest('button');
+				if (!btn) return;
+				const i = Number(btn.closest('.tarjeta').dataset.i);
+				const fotos = actual.p.gallery;
+				if (btn.dataset.accion === 'ocultar') {
+					if (fotos[i].hidden) delete fotos[i].hidden;
+					else fotos[i].hidden = true;
+				} else {
+					const yaEra = fotos[i].cover;
+					// La portada es única.
+					fotos.forEach((f) => delete f.cover);
+					if (!yaEra) fotos[i].cover = true;
+				}
+				pintar();
+				marcarSucio();
+			});
+
+			$('rejilla').addEventListener('dragstart', (e) => {
+				const t = e.target.closest('.tarjeta');
+				if (!t) return;
+				arrastrada = Number(t.dataset.i);
+				t.classList.add('arrastrando');
+				e.dataTransfer.effectAllowed = 'move';
+				// Sin esto el navegador no llega a disparar el soltado.
+				e.dataTransfer.setData('text/plain', String(arrastrada));
+			});
+
+			$('rejilla').addEventListener('dragover', (e) => {
+				e.preventDefault();
+				e.dataTransfer.dropEffect = 'move';
+				const t = e.target.closest('.tarjeta');
+				if (!t) return;
+				document.querySelectorAll('.destino').forEach((x) => x.classList.remove('destino'));
+				t.classList.add('destino');
+			});
+
+			$('rejilla').addEventListener('drop', (e) => {
+				e.preventDefault();
+				const t = e.target.closest('.tarjeta');
+				if (!t || arrastrada === null) return;
+				const destino = Number(t.dataset.i);
+				const [movida] = actual.p.gallery.splice(arrastrada, 1);
+				actual.p.gallery.splice(destino, 0, movida);
+				arrastrada = null;
+				pintar();
+				marcarSucio();
+			});
+
+			$('rejilla').addEventListener('dragend', () => {
+				document.querySelectorAll('.arrastrando, .destino').forEach((x) =>
+					x.classList.remove('arrastrando', 'destino'),
+				);
+				arrastrada = null;
+			});
+
+			$('proyecto').addEventListener('change', (e) => {
+				if (sucio && !confirm('Tienes cambios sin guardar. ¿Seguir sin guardarlos?')) {
+					return;
+				}
+				sucio = false;
+				$('guardar').disabled = true;
+				$('estado').textContent = '';
+				elegir(e.target.value);
+			});
+
+			$('guardar').addEventListener('click', async () => {
+				const f = ficheros.get(actual.ruta);
+				$('guardar').disabled = true;
+				$('estado').textContent = 'guardando...';
+				$('estado').className = 'estado';
+				try {
+					// Se reescribe el fichero entero a partir de lo que leímos, así que
+					// todos los demás campos viajan intactos: aquí solo se toca `gallery`.
+					const texto = JSON.stringify(f.datos, null, 4) + '\n';
+					const r = await api(`contents/${actual.ruta}`, {
+						method: 'PUT',
+						body: JSON.stringify({
+							message: `Ordenar fotos de ${actual.p.title}`,
+							content: aBase64(texto),
+							sha: f.sha,
+							branch: RAMA,
+						}),
+					});
+					f.sha = r.content.sha;
+					sucio = false;
+					$('estado').textContent = 'guardado';
+					$('estado').className = 'estado ok';
+				} catch (err) {
+					$('guardar').disabled = false;
+					const conflicto = /409|does not match/i.test(err.message);
+					$('estado').textContent = conflicto
+						? 'alguien guardó antes: recarga la página'
+						: 'no se pudo guardar';
+					$('estado').className = 'estado mal';
+					console.error(err);
+				}
+			});
+
+			window.addEventListener('beforeunload', (e) => {
+				if (sucio) e.preventDefault();
+			});
+
+			async function arrancar() {
+				await cargar();
+				montarSelector();
+				elegir($('proyecto').value);
+				$('entrada').classList.add('oculto');
+				$('app').classList.remove('oculto');
+			}
+
+			$('entrar').addEventListener('click', async () => {
+				token = $('token').value.trim();
+				$('errorEntrada').textContent = '';
+				try {
+					await arrancar();
+					localStorage.setItem('token-ordenar', token);
+				} catch (err) {
+					$('errorEntrada').textContent = 'No se pudo entrar. Revisa el token.';
+					console.error(err);
+				}
+			});
+
+			if (token) {
+				arrancar().catch(() => {
+					localStorage.removeItem('token-ordenar');
+				});
+			}
+		</script>
+	</body>
+</html>

--- a/src/content/editorials/editorials.json
+++ b/src/content/editorials/editorials.json
@@ -1,722 +1,723 @@
 {
-  "highlighted": [
-    {
-      "title": "Numéro - Miguel Herrán",
-      "description": "Editorial para Numéro Netherlands con Miguel Herrán.",
-      "gallery": [
+    "highlighted": [
         {
-          "file": "/assets/editorials/miguel-herran/1.webp",
-          "cover": true
+            "title": "Numéro - Miguel Herrán",
+            "description": "Editorial para Numéro Netherlands con Miguel Herrán.",
+            "gallery": [
+                {
+                    "file": "/assets/editorials/miguel-herran/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/miguel-herran/10.webp"
+                }
+            ],
+            "id": "miguel-herran",
+            "img": "/assets/editorials/miguel-herran/index.webp",
+            "img_alt": "Editorial Numéro - Miguel Herrán",
+            "cardSize": "normal",
+            "order": 2,
+            "role": "assistant-stylist",
+            "leadStylist": "Caterina Ospina",
+            "format": "editorial",
+            "credits": {
+                "photographer": "Sergio González @sergiognzalez",
+                "artDirection": "Sergio González @sergiognzalez",
+                "muah": "Fernando Torrent @torrentfernando para YSL Beauty",
+                "talent": "Miguel Herrán @miguel.g.herran",
+                "production": "Saik Prod @saikprod",
+                "location": "The Palace Madrid @thepalacemadrid"
+            }
         },
         {
-          "file": "/assets/editorials/miguel-herran/2.webp"
+            "title": "Vogue Adria",
+            "description": "Editorial para Vogue Adria.",
+            "gallery": [
+                {
+                    "file": "/assets/editorials/vogue/1.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/4.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/vogue/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/vogue/video-1.mp4"
+                }
+            ],
+            "pin": "first",
+            "id": "vogue",
+            "img": "/assets/editorials/vogue/index.webp",
+            "img_alt": "Editorial Vogue Adria",
+            "cardSize": "normal",
+            "order": 1,
+            "role": "assistant-stylist",
+            "leadStylist": "Caterina Ospina",
+            "format": "editorial",
+            "credits": {
+                "photographer": "Javier Biosca @javier_biosca",
+                "video": "Sergio González @sergiognzalez",
+                "makeup": "Alba Córdoba @albaxcordoba",
+                "hair": "Jesús de Paula @jesusdepaula",
+                "setDesign": "Isabel Adell @isadellc (asistente: Alborada MN @alboradamn)",
+                "talent": "Alice McGrath @alice_mcgrath_",
+                "talentAgency": "Uno Models @unomodels",
+                "production": "Saik Prod @saikprod",
+                "location": "Espacio La Candelaria @espacio_lacandelaria"
+            }
         },
         {
-          "file": "/assets/editorials/miguel-herran/3.webp"
+            "title": "Numéro - Martina Cariddi",
+            "description": "Editorial para Numéro Netherlands con Martina Cariddi.",
+            "gallery": [
+                {
+                    "file": "/assets/editorials/martina/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/martina/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/11.webp"
+                },
+                {
+                    "file": "/assets/editorials/martina/12.webp"
+                }
+            ],
+            "id": "martina",
+            "img": "/assets/editorials/martina/index.webp",
+            "img_alt": "Editorial Numéro - Martina Cariddi",
+            "cardSize": "normal",
+            "order": 3,
+            "role": "assistant-stylist",
+            "leadStylist": "Caterina Ospina",
+            "format": "editorial",
+            "credits": {
+                "photographer": "Sergio González @sergiognzalez",
+                "stylingTeam": "Verónica Faya @veronicafaya",
+                "makeup": "Cynthia de León @cynthiadeleon_",
+                "hair": "Jesús de Paula @jesusdepaula para Redken",
+                "talent": "Martina Cariddi @martinacariddi",
+                "production": "Saik Prod @saikprod",
+                "location": "Who Estudio @whoestudio"
+            }
         },
         {
-          "file": "/assets/editorials/miguel-herran/4.webp"
+            "title": "Numéro - Isabeli Fontana",
+            "description": "Editorial para Numéro Netherlands con Isabeli Fontana.",
+            "gallery": [
+                {
+                    "file": "/assets/editorials/isabeli/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/isabeli/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/11.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/12.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/13.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabeli/14.webp"
+                }
+            ],
+            "id": "isabeli",
+            "img": "/assets/editorials/isabeli/index.webp",
+            "img_alt": "Editorial Numéro - Isabeli Fontana",
+            "cardSize": "normal",
+            "order": 4,
+            "role": "assistant-stylist",
+            "leadStylist": "Caterina Ospina",
+            "format": "editorial",
+            "credits": {
+                "photographer": "Juankr @juankr_",
+                "stylingTeam": "Gema Balsalobre @gemabalsalobre1",
+                "makeup": "Iván Gómez @ivangomez",
+                "hair": "Fernando Torrent @torrentfernando",
+                "setDesign": "Isabel Adell @isadellc",
+                "talent": "Isabeli Fontana @isabelifontana",
+                "talentAgency": "The Lions Management @thelionsmgmt",
+                "production": "Saik Prod @saikprod"
+            }
         },
         {
-          "file": "/assets/editorials/miguel-herran/5.webp"
+            "title": "GQ - México",
+            "description": "Editorial para GQ México.",
+            "gallery": [
+                {
+                    "file": "/assets/editorials/gq/1.webp"
+                },
+                {
+                    "file": "/assets/editorials/gq/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/gq/3.webp",
+                    "cover": true
+                }
+            ],
+            "id": "gq",
+            "img": "/assets/editorials/gq/index.webp",
+            "img_alt": "Editorial GQ México",
+            "cardSize": "normal",
+            "order": 5,
+            "role": "assistant-stylist",
+            "leadStylist": "Caterina Ospina",
+            "format": "editorial",
+            "credits": {
+                "photographer": "Juankr @juankr_",
+                "stylingTeam": "Verónica Faya @veronicaonfaya y Gema Balsalobre @gemabalsalobre1",
+                "muah": "Antonio Romero @antonioromeromakeup",
+                "talent": "Walid Fiher @w3lidd",
+                "production": "Saik Prod @saikprod"
+            }
         },
         {
-          "file": "/assets/editorials/miguel-herran/6.webp"
+            "title": "Artego Magazine - Color Pop Garden",
+            "description": "Editorial «Color Pop Garden» para Artego Magazine.",
+            "gallery": [
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/11.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/12.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/13.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/14.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/15.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/16.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/17.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/18.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/19.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/20.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/21.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/22.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/23.webp"
+                },
+                {
+                    "file": "/assets/editorials/artego-color-pop-garden/24.webp"
+                }
+            ],
+            "id": "artego-color-pop-garden",
+            "img": "/assets/editorials/artego-color-pop-garden/index.webp",
+            "img_alt": "Editorial Artego Magazine - Color Pop Garden",
+            "cardSize": "normal",
+            "order": 6,
+            "role": "lead-stylist",
+            "format": "editorial",
+            "credits": {
+                "photographer": "Alex Guerra @aleguerrax",
+                "talent": "Kamila Iskairova @iskairova_",
+                "muah": "Diego Vitaller @muagami_beauty"
+            }
         },
         {
-          "file": "/assets/editorials/miguel-herran/7.webp"
+            "title": "pap magazine - The New Dandy",
+            "description": "Editorial «The New Dandy» para pap magazine.",
+            "gallery": [
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/11.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/12.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/13.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/14.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/15.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/16.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/17.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/18.webp"
+                }
+            ],
+            "id": "pap-the-new-dandy",
+            "img": "/assets/editorials/pap-the-new-dandy/index.webp",
+            "img_alt": "Editorial pap magazine - The New Dandy",
+            "cardSize": "normal",
+            "order": 7,
+            "role": "lead-stylist",
+            "format": "editorial",
+            "credits": {
+                "photographer": "Fio Vicente @fio.vicente",
+                "talent": "Álvaro García Narváez @alvarogarcianarvaez",
+                "muah": "Diego Vitaller @muagami_beauty",
+                "talentAgency": "The Road Models @theroadmodels",
+                "video": "Camilo Andrés @camilo5p"
+            }
         },
         {
-          "file": "/assets/editorials/miguel-herran/8.webp"
+            "title": "Folie Magazine - Always Love",
+            "description": "Editorial «Always Love» para Folie Magazine.",
+            "gallery": [
+                {
+                    "file": "/assets/editorials/folie-always-love/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/11.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/12.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/13.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/14.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-always-love/15.webp"
+                }
+            ],
+            "id": "folie-always-love",
+            "img": "/assets/editorials/folie-always-love/index.webp",
+            "img_alt": "Editorial Folie Magazine - Always Love",
+            "cardSize": "normal",
+            "order": 8,
+            "role": "lead-stylist",
+            "format": "editorial",
+            "credits": {
+                "photographer": "Leticia Díaz de la Morena @leticiadiazdelamorena",
+                "talent": "Charlotte Eva @charlotteeeva",
+                "muah": "Diego Vitaller @muagami_beauty"
+            }
         },
         {
-          "file": "/assets/editorials/miguel-herran/9.webp"
+            "title": "Folie Magazine - Soft Tension",
+            "description": "Editorial «Soft Tension» para Folie Magazine.",
+            "gallery": [
+                {
+                    "file": "/assets/editorials/folie-soft-tension/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/10.webp"
+                }
+            ],
+            "id": "folie-soft-tension",
+            "img": "/assets/editorials/folie-soft-tension/index.webp",
+            "img_alt": "Editorial Folie Magazine - Soft Tension",
+            "cardSize": "normal",
+            "order": 9,
+            "role": "lead-stylist",
+            "format": "editorial",
+            "credits": {
+                "photographer": "Diego G. @diego_v_photo",
+                "talent": "Luca Darblade @luca_darblade",
+                "muah": "Diego Vitaller @muagami_beauty",
+                "talentAgency": "Wanted Agency @wantedagency"
+            }
         },
         {
-          "file": "/assets/editorials/miguel-herran/10.webp"
+            "title": "Mode Magazine - Isabel Arbós",
+            "description": "Editorial para Mode Magazine con Isabel Arbós.",
+            "gallery": [
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/28.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/2.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/1.webp",
+                    "hidden": true,
+                    "cover": false
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/5.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/6.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/9.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/11.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/12.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/13.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/14.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/15.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/16.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/17.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/18.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/19.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/20.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/21.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/22.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/23.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/24.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/25.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/26.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/27.webp"
+                },
+                {
+                    "file": "/assets/editorials/isabel-arbos-model-test/3.webp"
+                }
+            ],
+            "id": "isabel-arbos-model-test",
+            "img": "/assets/editorials/isabel-arbos-model-test/index.webp",
+            "img_alt": "Editorial Mode Magazine con Isabel Arbós",
+            "cardSize": "normal",
+            "order": 10,
+            "role": "lead-stylist",
+            "format": "editorial",
+            "credits": {
+                "photographer": "Paulo Herrera @pauloherrera.foto",
+                "talent": "Isabel Arbós @isabel_arbos",
+                "muah": "Diego Vitaller @muagami_beauty",
+                "talentAgency": "Six Management @sixmanagement.es"
+            }
+        },
+        {
+            "title": "Mode Magazine - Aminata Sarr",
+            "description": "Editorial para Mode Magazine con Aminata Sarr.",
+            "gallery": [
+                {
+                    "file": "/assets/editorials/aminata/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/aminata/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/aminata/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/aminata/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/aminata/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/aminata/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/aminata/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/aminata/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/aminata/9.webp"
+                }
+            ],
+            "pin": "last",
+            "id": "aminata",
+            "img": "/assets/editorials/aminata/index.webp",
+            "img_alt": "Editorial Mode Magazine con Aminata Sarr",
+            "cardSize": "normal",
+            "order": 11,
+            "role": "lead-stylist",
+            "format": "editorial",
+            "credits": {
+                "photographer": "@shots_cv",
+                "talent": "Aminata Sarr @aminata.sr",
+                "hair": "@f0urt4zz",
+                "makeup": "@nermosu_"
+            }
         }
-      ],
-      "id": "miguel-herran",
-      "img": "/assets/editorials/miguel-herran/index.webp",
-      "img_alt": "Editorial Numéro - Miguel Herrán",
-      "cardSize": "normal",
-      "order": 2,
-      "role": "assistant-stylist",
-      "leadStylist": "Caterina Ospina",
-      "format": "editorial",
-      "credits": {
-        "photographer": "Sergio González @sergiognzalez",
-        "artDirection": "Sergio González @sergiognzalez",
-        "muah": "Fernando Torrent @torrentfernando para YSL Beauty",
-        "talent": "Miguel Herrán @miguel.g.herran",
-        "production": "Saik Prod @saikprod",
-        "location": "The Palace Madrid @thepalacemadrid"
-      }
-    },
-    {
-      "title": "Vogue Adria",
-      "description": "Editorial para Vogue Adria.",
-      "gallery": [
-        {
-          "file": "/assets/editorials/vogue/1.webp"
-        },
-        {
-          "file": "/assets/editorials/vogue/2.webp"
-        },
-        {
-          "file": "/assets/editorials/vogue/3.webp"
-        },
-        {
-          "file": "/assets/editorials/vogue/4.webp",
-          "cover": true
-        },
-        {
-          "file": "/assets/editorials/vogue/5.webp"
-        },
-        {
-          "file": "/assets/editorials/vogue/6.webp"
-        },
-        {
-          "file": "/assets/editorials/vogue/7.webp"
-        },
-        {
-          "file": "/assets/editorials/vogue/8.webp"
-        },
-        {
-          "file": "/assets/editorials/vogue/9.webp"
-        },
-        {
-          "file": "/assets/editorials/vogue/10.webp"
-        },
-        {
-          "file": "/assets/editorials/vogue/video-1.mp4"
-        }
-      ],
-      "pin": "first",
-      "id": "vogue",
-      "img": "/assets/editorials/vogue/index.webp",
-      "img_alt": "Editorial Vogue Adria",
-      "cardSize": "normal",
-      "order": 1,
-      "role": "assistant-stylist",
-      "leadStylist": "Caterina Ospina",
-      "format": "editorial",
-      "credits": {
-        "photographer": "Javier Biosca @javier_biosca",
-        "video": "Sergio González @sergiognzalez",
-        "makeup": "Alba Córdoba @albaxcordoba",
-        "hair": "Jesús de Paula @jesusdepaula",
-        "setDesign": "Isabel Adell @isadellc (asistente: Alborada MN @alboradamn)",
-        "talent": "Alice McGrath @alice_mcgrath_",
-        "talentAgency": "Uno Models @unomodels",
-        "production": "Saik Prod @saikprod",
-        "location": "Espacio La Candelaria @espacio_lacandelaria"
-      }
-    },
-    {
-      "title": "Numéro - Martina Cariddi",
-      "description": "Editorial para Numéro Netherlands con Martina Cariddi.",
-      "gallery": [
-        {
-          "file": "/assets/editorials/martina/1.webp",
-          "cover": true
-        },
-        {
-          "file": "/assets/editorials/martina/2.webp"
-        },
-        {
-          "file": "/assets/editorials/martina/3.webp"
-        },
-        {
-          "file": "/assets/editorials/martina/4.webp"
-        },
-        {
-          "file": "/assets/editorials/martina/5.webp"
-        },
-        {
-          "file": "/assets/editorials/martina/6.webp"
-        },
-        {
-          "file": "/assets/editorials/martina/7.webp"
-        },
-        {
-          "file": "/assets/editorials/martina/8.webp"
-        },
-        {
-          "file": "/assets/editorials/martina/9.webp"
-        },
-        {
-          "file": "/assets/editorials/martina/10.webp"
-        },
-        {
-          "file": "/assets/editorials/martina/11.webp"
-        },
-        {
-          "file": "/assets/editorials/martina/12.webp"
-        }
-      ],
-      "id": "martina",
-      "img": "/assets/editorials/martina/index.webp",
-      "img_alt": "Editorial Numéro - Martina Cariddi",
-      "cardSize": "normal",
-      "order": 3,
-      "role": "assistant-stylist",
-      "leadStylist": "Caterina Ospina",
-      "format": "editorial",
-      "credits": {
-        "photographer": "Sergio González @sergiognzalez",
-        "stylingTeam": "Verónica Faya @veronicafaya",
-        "makeup": "Cynthia de León @cynthiadeleon_",
-        "hair": "Jesús de Paula @jesusdepaula para Redken",
-        "talent": "Martina Cariddi @martinacariddi",
-        "production": "Saik Prod @saikprod",
-        "location": "Who Estudio @whoestudio"
-      }
-    },
-    {
-      "title": "Numéro - Isabeli Fontana",
-      "description": "Editorial para Numéro Netherlands con Isabeli Fontana.",
-      "gallery": [
-        {
-          "file": "/assets/editorials/isabeli/1.webp",
-          "cover": true
-        },
-        {
-          "file": "/assets/editorials/isabeli/2.webp"
-        },
-        {
-          "file": "/assets/editorials/isabeli/3.webp"
-        },
-        {
-          "file": "/assets/editorials/isabeli/4.webp"
-        },
-        {
-          "file": "/assets/editorials/isabeli/5.webp"
-        },
-        {
-          "file": "/assets/editorials/isabeli/6.webp"
-        },
-        {
-          "file": "/assets/editorials/isabeli/7.webp"
-        },
-        {
-          "file": "/assets/editorials/isabeli/8.webp"
-        },
-        {
-          "file": "/assets/editorials/isabeli/9.webp"
-        },
-        {
-          "file": "/assets/editorials/isabeli/10.webp"
-        },
-        {
-          "file": "/assets/editorials/isabeli/11.webp"
-        },
-        {
-          "file": "/assets/editorials/isabeli/12.webp"
-        },
-        {
-          "file": "/assets/editorials/isabeli/13.webp"
-        },
-        {
-          "file": "/assets/editorials/isabeli/14.webp"
-        }
-      ],
-      "id": "isabeli",
-      "img": "/assets/editorials/isabeli/index.webp",
-      "img_alt": "Editorial Numéro - Isabeli Fontana",
-      "cardSize": "normal",
-      "order": 4,
-      "role": "assistant-stylist",
-      "leadStylist": "Caterina Ospina",
-      "format": "editorial",
-      "credits": {
-        "photographer": "Juankr @juankr_",
-        "stylingTeam": "Gema Balsalobre @gemabalsalobre1",
-        "makeup": "Iván Gómez @ivangomez",
-        "hair": "Fernando Torrent @torrentfernando",
-        "setDesign": "Isabel Adell @isadellc",
-        "talent": "Isabeli Fontana @isabelifontana",
-        "talentAgency": "The Lions Management @thelionsmgmt",
-        "production": "Saik Prod @saikprod"
-      }
-    },
-    {
-      "title": "GQ - México",
-      "description": "Editorial para GQ México.",
-      "gallery": [
-        {
-          "file": "/assets/editorials/gq/1.webp"
-        },
-        {
-          "file": "/assets/editorials/gq/2.webp"
-        },
-        {
-          "file": "/assets/editorials/gq/3.webp",
-          "cover": true
-        }
-      ],
-      "id": "gq",
-      "img": "/assets/editorials/gq/index.webp",
-      "img_alt": "Editorial GQ México",
-      "cardSize": "normal",
-      "order": 5,
-      "role": "assistant-stylist",
-      "leadStylist": "Caterina Ospina",
-      "format": "editorial",
-      "credits": {
-        "photographer": "Juankr @juankr_",
-        "stylingTeam": "Verónica Faya @veronicaonfaya y Gema Balsalobre @gemabalsalobre1",
-        "muah": "Antonio Romero @antonioromeromakeup",
-        "talent": "Walid Fiher @w3lidd",
-        "production": "Saik Prod @saikprod"
-      }
-    },
-    {
-      "title": "Artego Magazine - Color Pop Garden",
-      "description": "Editorial «Color Pop Garden» para Artego Magazine.",
-      "gallery": [
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/1.webp",
-          "cover": true
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/2.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/3.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/4.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/5.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/6.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/7.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/8.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/9.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/10.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/11.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/12.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/13.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/14.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/15.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/16.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/17.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/18.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/19.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/20.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/21.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/22.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/23.webp"
-        },
-        {
-          "file": "/assets/editorials/artego-color-pop-garden/24.webp"
-        }
-      ],
-      "id": "artego-color-pop-garden",
-      "img": "/assets/editorials/artego-color-pop-garden/index.webp",
-      "img_alt": "Editorial Artego Magazine - Color Pop Garden",
-      "cardSize": "normal",
-      "order": 6,
-      "role": "lead-stylist",
-      "format": "editorial",
-      "credits": {
-        "photographer": "Alex Guerra @aleguerrax",
-        "talent": "Kamila Iskairova @iskairova_",
-        "muah": "Diego Vitaller @muagami_beauty"
-      }
-    },
-    {
-      "title": "pap magazine - The New Dandy",
-      "description": "Editorial «The New Dandy» para pap magazine.",
-      "gallery": [
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/1.webp",
-          "cover": true
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/2.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/3.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/4.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/5.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/6.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/7.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/8.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/9.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/10.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/11.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/12.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/13.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/14.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/15.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/16.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/17.webp"
-        },
-        {
-          "file": "/assets/editorials/pap-the-new-dandy/18.webp"
-        }
-      ],
-      "id": "pap-the-new-dandy",
-      "img": "/assets/editorials/pap-the-new-dandy/index.webp",
-      "img_alt": "Editorial pap magazine - The New Dandy",
-      "cardSize": "normal",
-      "order": 7,
-      "role": "lead-stylist",
-      "format": "editorial",
-      "credits": {
-        "photographer": "Fio Vicente @fio.vicente",
-        "talent": "Álvaro García Narváez @alvarogarcianarvaez",
-        "muah": "Diego Vitaller @muagami_beauty",
-        "talentAgency": "The Road Models @theroadmodels",
-        "video": "Camilo Andrés @camilo5p"
-      }
-    },
-    {
-      "title": "Folie Magazine - Always Love",
-      "description": "Editorial «Always Love» para Folie Magazine.",
-      "gallery": [
-        {
-          "file": "/assets/editorials/folie-always-love/1.webp",
-          "cover": true
-        },
-        {
-          "file": "/assets/editorials/folie-always-love/2.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-always-love/3.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-always-love/4.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-always-love/5.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-always-love/6.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-always-love/7.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-always-love/8.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-always-love/9.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-always-love/10.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-always-love/11.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-always-love/12.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-always-love/13.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-always-love/14.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-always-love/15.webp"
-        }
-      ],
-      "id": "folie-always-love",
-      "img": "/assets/editorials/folie-always-love/index.webp",
-      "img_alt": "Editorial Folie Magazine - Always Love",
-      "cardSize": "normal",
-      "order": 8,
-      "role": "lead-stylist",
-      "format": "editorial",
-      "credits": {
-        "photographer": "Leticia Díaz de la Morena @leticiadiazdelamorena",
-        "talent": "Charlotte Eva @charlotteeeva",
-        "muah": "Diego Vitaller @muagami_beauty"
-      }
-    },
-    {
-      "title": "Folie Magazine - Soft Tension",
-      "description": "Editorial «Soft Tension» para Folie Magazine.",
-      "gallery": [
-        {
-          "file": "/assets/editorials/folie-soft-tension/1.webp",
-          "cover": true
-        },
-        {
-          "file": "/assets/editorials/folie-soft-tension/2.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-soft-tension/3.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-soft-tension/4.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-soft-tension/5.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-soft-tension/6.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-soft-tension/7.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-soft-tension/8.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-soft-tension/9.webp"
-        },
-        {
-          "file": "/assets/editorials/folie-soft-tension/10.webp"
-        }
-      ],
-      "id": "folie-soft-tension",
-      "img": "/assets/editorials/folie-soft-tension/index.webp",
-      "img_alt": "Editorial Folie Magazine - Soft Tension",
-      "cardSize": "normal",
-      "order": 9,
-      "role": "lead-stylist",
-      "format": "editorial",
-      "credits": {
-        "photographer": "Diego G. @diego_v_photo",
-        "talent": "Luca Darblade @luca_darblade",
-        "muah": "Diego Vitaller @muagami_beauty",
-        "talentAgency": "Wanted Agency @wantedagency"
-      }
-    },
-    {
-      "title": "Mode Magazine - Isabel Arbós",
-      "description": "Editorial para Mode Magazine con Isabel Arbós.",
-      "gallery": [
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/28.webp",
-          "cover": true
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/2.webp"
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/1.webp",
-          "hidden": true,
-          "cover": false
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/4.webp"
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/5.webp",
-          "hidden": true
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/6.webp",
-          "hidden": true
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/7.webp"
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/8.webp"
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/9.webp",
-          "hidden": true
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/10.webp"
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/11.webp",
-          "hidden": true
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/12.webp"
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/13.webp"
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/14.webp"
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/15.webp"
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/16.webp",
-          "hidden": true
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/17.webp",
-          "hidden": true
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/18.webp",
-          "hidden": true
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/19.webp",
-          "hidden": true
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/20.webp"
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/21.webp",
-          "hidden": true
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/22.webp",
-          "hidden": true
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/23.webp",
-          "hidden": true
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/24.webp"
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/25.webp",
-          "hidden": true
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/26.webp",
-          "hidden": true
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/27.webp"
-        },
-        {
-          "file": "/assets/editorials/isabel-arbos-model-test/3.webp"
-        }
-      ],
-      "id": "isabel-arbos-model-test",
-      "img": "/assets/editorials/isabel-arbos-model-test/index.webp",
-      "img_alt": "Editorial Mode Magazine con Isabel Arbós",
-      "cardSize": "normal",
-      "order": 10,
-      "role": "lead-stylist",
-      "format": "editorial",
-      "credits": {
-        "photographer": "Paulo Herrera @pauloherrera.foto",
-        "talent": "Isabel Arbós @isabel_arbos",
-        "muah": "Diego Vitaller @muagami_beauty",
-        "talentAgency": "Six Management @sixmanagement.es"
-      }
-    },
-    {
-      "title": "Mode Magazine - Aminata Sarr",
-      "description": "Editorial para Mode Magazine con Aminata Sarr.",
-      "gallery": [
-        {
-          "file": "/assets/editorials/aminata/1.webp",
-          "cover": true
-        },
-        {
-          "file": "/assets/editorials/aminata/2.webp"
-        },
-        {
-          "file": "/assets/editorials/aminata/3.webp"
-        },
-        {
-          "file": "/assets/editorials/aminata/4.webp"
-        },
-        {
-          "file": "/assets/editorials/aminata/5.webp"
-        },
-        {
-          "file": "/assets/editorials/aminata/6.webp"
-        },
-        {
-          "file": "/assets/editorials/aminata/7.webp"
-        },
-        {
-          "file": "/assets/editorials/aminata/8.webp"
-        },
-        {
-          "file": "/assets/editorials/aminata/9.webp"
-        }
-      ],
-      "pin": "last",
-      "id": "aminata",
-      "img": "/assets/editorials/aminata/index.webp",
-      "img_alt": "Editorial Mode Magazine con Aminata Sarr",
-      "cardSize": "normal",
-      "order": 11,
-      "role": "lead-stylist",
-      "format": "editorial",
-      "credits": {
-        "photographer": "@shots_cv",
-        "talent": "Aminata Sarr @aminata.sr",
-        "hair": "@f0urt4zz",
-        "makeup": "@nermosu_"
-      }
-    }
-  ]
+    ]
 }

--- a/src/content/editorials/editorials.json
+++ b/src/content/editorials/editorials.json
@@ -560,8 +560,7 @@
                     "cover": true
                 },
                 {
-                    "file": "/assets/editorials/isabel-arbos-model-test/2.webp",
-                    "hidden": true
+                    "file": "/assets/editorials/isabel-arbos-model-test/2.webp"
                 },
                 {
                     "file": "/assets/editorials/isabel-arbos-model-test/1.webp",

--- a/src/content/editorials/editorials.json
+++ b/src/content/editorials/editorials.json
@@ -1,708 +1,722 @@
 {
-    "highlighted": [
+  "highlighted": [
+    {
+      "title": "Numéro - Miguel Herrán",
+      "description": "Editorial para Numéro Netherlands con Miguel Herrán.",
+      "gallery": [
         {
-            "title": "Numéro - Miguel Herrán",
-            "description": "Editorial para Numéro Netherlands con Miguel Herrán.",
-            "gallery": [
-                {
-                    "file": "/assets/editorials/miguel-herran/1.webp",
-                    "cover": true
-                },
-                {
-                    "file": "/assets/editorials/miguel-herran/2.webp"
-                },
-                {
-                    "file": "/assets/editorials/miguel-herran/3.webp"
-                },
-                {
-                    "file": "/assets/editorials/miguel-herran/4.webp"
-                },
-                {
-                    "file": "/assets/editorials/miguel-herran/5.webp"
-                },
-                {
-                    "file": "/assets/editorials/miguel-herran/6.webp"
-                },
-                {
-                    "file": "/assets/editorials/miguel-herran/7.webp"
-                },
-                {
-                    "file": "/assets/editorials/miguel-herran/8.webp"
-                },
-                {
-                    "file": "/assets/editorials/miguel-herran/9.webp"
-                },
-                {
-                    "file": "/assets/editorials/miguel-herran/10.webp"
-                }
-            ],
-            "id": "miguel-herran",
-            "img": "/assets/editorials/miguel-herran/index.webp",
-            "img_alt": "Editorial Numéro - Miguel Herrán",
-            "cardSize": "normal",
-            "order": 2,
-            "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina",
-            "format": "editorial",
-            "credits": {
-                "location": "The Palace Madrid @thepalacemadrid",
-                "production": "Saik Prod @saikprod",
-                "talent": "Miguel Herrán @miguel.g.herran",
-                "muah": "Fernando Torrent @torrentfernando para YSL Beauty",
-                "artDirection": "Sergio González @sergiognzalez",
-                "photographer": "Sergio González @sergiognzalez"
-            }
+          "file": "/assets/editorials/miguel-herran/1.webp",
+          "cover": true
         },
         {
-            "title": "Vogue Adria",
-            "description": "Editorial para Vogue Adria.",
-            "gallery": [
-                {
-                    "file": "/assets/editorials/vogue/1.webp"
-                },
-                {
-                    "file": "/assets/editorials/vogue/2.webp"
-                },
-                {
-                    "file": "/assets/editorials/vogue/3.webp"
-                },
-                {
-                    "file": "/assets/editorials/vogue/4.webp",
-                    "cover": true
-                },
-                {
-                    "file": "/assets/editorials/vogue/5.webp"
-                },
-                {
-                    "file": "/assets/editorials/vogue/6.webp"
-                },
-                {
-                    "file": "/assets/editorials/vogue/7.webp"
-                },
-                {
-                    "file": "/assets/editorials/vogue/8.webp"
-                },
-                {
-                    "file": "/assets/editorials/vogue/9.webp"
-                },
-                {
-                    "file": "/assets/editorials/vogue/10.webp"
-                },
-                {
-                    "file": "/assets/editorials/vogue/video-1.mp4"
-                }
-            ],
-            "pin": "first",
-            "id": "vogue",
-            "img": "/assets/editorials/vogue/index.webp",
-            "img_alt": "Editorial Vogue Adria",
-            "cardSize": "normal",
-            "order": 1,
-            "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina",
-            "format": "editorial",
-            "credits": {
-                "location": "Espacio La Candelaria @espacio_lacandelaria",
-                "production": "Saik Prod @saikprod",
-                "talentAgency": "Uno Models @unomodels",
-                "talent": "Alice McGrath @alice_mcgrath_",
-                "setDesign": "Isabel Adell @isadellc (asistente: Alborada MN @alboradamn)",
-                "hair": "Jesús de Paula @jesusdepaula",
-                "makeup": "Alba Córdoba @albaxcordoba",
-                "video": "Sergio González @sergiognzalez",
-                "photographer": "Javier Biosca @javier_biosca"
-            }
+          "file": "/assets/editorials/miguel-herran/2.webp"
         },
         {
-            "title": "Numéro - Martina Cariddi",
-            "description": "Editorial para Numéro Netherlands con Martina Cariddi.",
-            "gallery": [
-                {
-                    "file": "/assets/editorials/martina/1.webp",
-                    "cover": true
-                },
-                {
-                    "file": "/assets/editorials/martina/2.webp"
-                },
-                {
-                    "file": "/assets/editorials/martina/3.webp"
-                },
-                {
-                    "file": "/assets/editorials/martina/4.webp"
-                },
-                {
-                    "file": "/assets/editorials/martina/5.webp"
-                },
-                {
-                    "file": "/assets/editorials/martina/6.webp"
-                },
-                {
-                    "file": "/assets/editorials/martina/7.webp"
-                },
-                {
-                    "file": "/assets/editorials/martina/8.webp"
-                },
-                {
-                    "file": "/assets/editorials/martina/9.webp"
-                },
-                {
-                    "file": "/assets/editorials/martina/10.webp"
-                },
-                {
-                    "file": "/assets/editorials/martina/11.webp"
-                },
-                {
-                    "file": "/assets/editorials/martina/12.webp"
-                }
-            ],
-            "id": "martina",
-            "img": "/assets/editorials/martina/index.webp",
-            "img_alt": "Editorial Numéro - Martina Cariddi",
-            "cardSize": "normal",
-            "order": 3,
-            "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina",
-            "format": "editorial",
-            "credits": {
-                "location": "Who Estudio @whoestudio",
-                "production": "Saik Prod @saikprod",
-                "talent": "Martina Cariddi @martinacariddi",
-                "hair": "Jesús de Paula @jesusdepaula para Redken",
-                "makeup": "Cynthia de León @cynthiadeleon_",
-                "stylingTeam": "Verónica Faya @veronicafaya",
-                "photographer": "Sergio González @sergiognzalez"
-            }
+          "file": "/assets/editorials/miguel-herran/3.webp"
         },
         {
-            "title": "Numéro - Isabeli Fontana",
-            "description": "Editorial para Numéro Netherlands con Isabeli Fontana.",
-            "gallery": [
-                {
-                    "file": "/assets/editorials/isabeli/1.webp",
-                    "cover": true
-                },
-                {
-                    "file": "/assets/editorials/isabeli/2.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabeli/3.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabeli/4.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabeli/5.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabeli/6.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabeli/7.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabeli/8.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabeli/9.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabeli/10.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabeli/11.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabeli/12.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabeli/13.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabeli/14.webp"
-                }
-            ],
-            "id": "isabeli",
-            "img": "/assets/editorials/isabeli/index.webp",
-            "img_alt": "Editorial Numéro - Isabeli Fontana",
-            "cardSize": "normal",
-            "order": 4,
-            "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina",
-            "format": "editorial",
-            "credits": {
-                "production": "Saik Prod @saikprod",
-                "talentAgency": "The Lions Management @thelionsmgmt",
-                "talent": "Isabeli Fontana @isabelifontana",
-                "setDesign": "Isabel Adell @isadellc",
-                "hair": "Fernando Torrent @torrentfernando",
-                "makeup": "Iván Gómez @ivangomez",
-                "stylingTeam": "Gema Balsalobre @gemabalsalobre1",
-                "photographer": "Juankr @juankr_"
-            }
+          "file": "/assets/editorials/miguel-herran/4.webp"
         },
         {
-            "title": "GQ - México",
-            "description": "Editorial para GQ México.",
-            "gallery": [
-                {
-                    "file": "/assets/editorials/gq/1.webp"
-                },
-                {
-                    "file": "/assets/editorials/gq/2.webp"
-                },
-                {
-                    "file": "/assets/editorials/gq/3.webp",
-                    "cover": true
-                }
-            ],
-            "id": "gq",
-            "img": "/assets/editorials/gq/index.webp",
-            "img_alt": "Editorial GQ México",
-            "cardSize": "normal",
-            "order": 5,
-            "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina",
-            "format": "editorial",
-            "credits": {
-                "production": "Saik Prod @saikprod",
-                "talent": "Walid Fiher @w3lidd",
-                "muah": "Antonio Romero @antonioromeromakeup",
-                "stylingTeam": "Verónica Faya @veronicaonfaya y Gema Balsalobre @gemabalsalobre1",
-                "photographer": "Juankr @juankr_"
-            }
+          "file": "/assets/editorials/miguel-herran/5.webp"
         },
         {
-            "title": "Artego Magazine - Color Pop Garden",
-            "description": "Editorial «Color Pop Garden» para Artego Magazine.",
-            "gallery": [
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/1.webp",
-                    "cover": true
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/2.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/3.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/4.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/5.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/6.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/7.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/8.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/9.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/10.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/11.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/12.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/13.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/14.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/15.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/16.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/17.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/18.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/19.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/20.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/21.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/22.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/23.webp"
-                },
-                {
-                    "file": "/assets/editorials/artego-color-pop-garden/24.webp"
-                }
-            ],
-            "id": "artego-color-pop-garden",
-            "img": "/assets/editorials/artego-color-pop-garden/index.webp",
-            "img_alt": "Editorial Artego Magazine - Color Pop Garden",
-            "cardSize": "normal",
-            "order": 6,
-            "role": "lead-stylist",
-            "format": "editorial",
-            "credits": {
-                "muah": "Diego Vitaller @muagami_beauty",
-                "talent": "Kamila Iskairova @iskairova_",
-                "photographer": "Alex Guerra @aleguerrax"
-            }
+          "file": "/assets/editorials/miguel-herran/6.webp"
         },
         {
-            "title": "pap magazine - The New Dandy",
-            "description": "Editorial «The New Dandy» para pap magazine.",
-            "gallery": [
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/1.webp",
-                    "cover": true
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/2.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/3.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/4.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/5.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/6.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/7.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/8.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/9.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/10.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/11.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/12.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/13.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/14.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/15.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/16.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/17.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/18.webp"
-                }
-            ],
-            "id": "pap-the-new-dandy",
-            "img": "/assets/editorials/pap-the-new-dandy/index.webp",
-            "img_alt": "Editorial pap magazine - The New Dandy",
-            "cardSize": "normal",
-            "order": 7,
-            "role": "lead-stylist",
-            "format": "editorial",
-            "credits": {
-                "video": "Camilo Andrés @camilo5p",
-                "talentAgency": "The Road Models @theroadmodels",
-                "muah": "Diego Vitaller @muagami_beauty",
-                "talent": "Álvaro García Narváez @alvarogarcianarvaez",
-                "photographer": "Fio Vicente @fio.vicente"
-            }
+          "file": "/assets/editorials/miguel-herran/7.webp"
         },
         {
-            "title": "Folie Magazine - Always Love",
-            "description": "Editorial «Always Love» para Folie Magazine.",
-            "gallery": [
-                {
-                    "file": "/assets/editorials/folie-always-love/1.webp",
-                    "cover": true
-                },
-                {
-                    "file": "/assets/editorials/folie-always-love/2.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-always-love/3.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-always-love/4.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-always-love/5.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-always-love/6.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-always-love/7.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-always-love/8.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-always-love/9.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-always-love/10.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-always-love/11.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-always-love/12.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-always-love/13.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-always-love/14.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-always-love/15.webp"
-                }
-            ],
-            "id": "folie-always-love",
-            "img": "/assets/editorials/folie-always-love/index.webp",
-            "img_alt": "Editorial Folie Magazine - Always Love",
-            "cardSize": "normal",
-            "order": 8,
-            "role": "lead-stylist",
-            "format": "editorial",
-            "credits": {
-                "muah": "Diego Vitaller @muagami_beauty",
-                "talent": "Charlotte Eva @charlotteeeva",
-                "photographer": "Leticia Díaz de la Morena @leticiadiazdelamorena"
-            }
+          "file": "/assets/editorials/miguel-herran/8.webp"
         },
         {
-            "title": "Folie Magazine - Soft Tension",
-            "description": "Editorial «Soft Tension» para Folie Magazine.",
-            "gallery": [
-                {
-                    "file": "/assets/editorials/folie-soft-tension/1.webp",
-                    "cover": true
-                },
-                {
-                    "file": "/assets/editorials/folie-soft-tension/2.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-soft-tension/3.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-soft-tension/4.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-soft-tension/5.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-soft-tension/6.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-soft-tension/7.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-soft-tension/8.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-soft-tension/9.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-soft-tension/10.webp"
-                }
-            ],
-            "id": "folie-soft-tension",
-            "img": "/assets/editorials/folie-soft-tension/index.webp",
-            "img_alt": "Editorial Folie Magazine - Soft Tension",
-            "cardSize": "normal",
-            "order": 9,
-            "role": "lead-stylist",
-            "format": "editorial",
-            "credits": {
-                "talentAgency": "Wanted Agency @wantedagency",
-                "muah": "Diego Vitaller @muagami_beauty",
-                "talent": "Luca Darblade @luca_darblade",
-                "photographer": "Diego G. @diego_v_photo"
-            }
+          "file": "/assets/editorials/miguel-herran/9.webp"
         },
         {
-            "title": "Mode Magazine - Isabel Arbós",
-            "description": "Editorial para Mode Magazine con Isabel Arbós.",
-            "gallery": [
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/1.webp",
-                    "cover": false
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/2.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/3.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/4.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/5.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/6.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/7.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/8.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/9.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/10.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/11.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/12.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/13.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/14.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/15.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/16.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/17.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/18.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/19.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/20.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/21.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/22.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/23.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/24.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/25.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/26.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/27.webp"
-                },
-                {
-                    "file": "/assets/editorials/isabel-arbos-model-test/28.webp",
-                    "cover": true
-                }
-            ],
-            "id": "isabel-arbos-model-test",
-            "img": "/assets/editorials/isabel-arbos-model-test/index.webp",
-            "img_alt": "Editorial Mode Magazine con Isabel Arbós",
-            "cardSize": "normal",
-            "order": 10,
-            "role": "lead-stylist",
-            "format": "editorial",
-            "credits": {
-                "talentAgency": "Six Management @sixmanagement.es",
-                "muah": "Diego Vitaller @muagami_beauty",
-                "talent": "Isabel Arbós @isabel_arbos",
-                "photographer": "Paulo Herrera @pauloherrera.foto"
-            }
-        },
-        {
-            "title": "Mode Magazine - Aminata Sarr",
-            "description": "Editorial para Mode Magazine con Aminata Sarr.",
-            "gallery": [
-                {
-                    "file": "/assets/editorials/aminata/1.webp",
-                    "cover": true
-                },
-                {
-                    "file": "/assets/editorials/aminata/2.webp"
-                },
-                {
-                    "file": "/assets/editorials/aminata/3.webp"
-                },
-                {
-                    "file": "/assets/editorials/aminata/4.webp"
-                },
-                {
-                    "file": "/assets/editorials/aminata/5.webp"
-                },
-                {
-                    "file": "/assets/editorials/aminata/6.webp"
-                },
-                {
-                    "file": "/assets/editorials/aminata/7.webp"
-                },
-                {
-                    "file": "/assets/editorials/aminata/8.webp"
-                },
-                {
-                    "file": "/assets/editorials/aminata/9.webp"
-                }
-            ],
-            "pin": "last",
-            "id": "aminata",
-            "img": "/assets/editorials/aminata/index.webp",
-            "img_alt": "Editorial Mode Magazine con Aminata Sarr",
-            "cardSize": "normal",
-            "order": 11,
-            "role": "lead-stylist",
-            "format": "editorial",
-            "credits": {
-                "makeup": "@nermosu_",
-                "hair": "@f0urt4zz",
-                "talent": "Aminata Sarr @aminata.sr",
-                "photographer": "@shots_cv"
-            }
+          "file": "/assets/editorials/miguel-herran/10.webp"
         }
-    ]
+      ],
+      "id": "miguel-herran",
+      "img": "/assets/editorials/miguel-herran/index.webp",
+      "img_alt": "Editorial Numéro - Miguel Herrán",
+      "cardSize": "normal",
+      "order": 2,
+      "role": "assistant-stylist",
+      "leadStylist": "Caterina Ospina",
+      "format": "editorial",
+      "credits": {
+        "photographer": "Sergio González @sergiognzalez",
+        "artDirection": "Sergio González @sergiognzalez",
+        "muah": "Fernando Torrent @torrentfernando para YSL Beauty",
+        "talent": "Miguel Herrán @miguel.g.herran",
+        "production": "Saik Prod @saikprod",
+        "location": "The Palace Madrid @thepalacemadrid"
+      }
+    },
+    {
+      "title": "Vogue Adria",
+      "description": "Editorial para Vogue Adria.",
+      "gallery": [
+        {
+          "file": "/assets/editorials/vogue/1.webp"
+        },
+        {
+          "file": "/assets/editorials/vogue/2.webp"
+        },
+        {
+          "file": "/assets/editorials/vogue/3.webp"
+        },
+        {
+          "file": "/assets/editorials/vogue/4.webp",
+          "cover": true
+        },
+        {
+          "file": "/assets/editorials/vogue/5.webp"
+        },
+        {
+          "file": "/assets/editorials/vogue/6.webp"
+        },
+        {
+          "file": "/assets/editorials/vogue/7.webp"
+        },
+        {
+          "file": "/assets/editorials/vogue/8.webp"
+        },
+        {
+          "file": "/assets/editorials/vogue/9.webp"
+        },
+        {
+          "file": "/assets/editorials/vogue/10.webp"
+        },
+        {
+          "file": "/assets/editorials/vogue/video-1.mp4"
+        }
+      ],
+      "pin": "first",
+      "id": "vogue",
+      "img": "/assets/editorials/vogue/index.webp",
+      "img_alt": "Editorial Vogue Adria",
+      "cardSize": "normal",
+      "order": 1,
+      "role": "assistant-stylist",
+      "leadStylist": "Caterina Ospina",
+      "format": "editorial",
+      "credits": {
+        "photographer": "Javier Biosca @javier_biosca",
+        "video": "Sergio González @sergiognzalez",
+        "makeup": "Alba Córdoba @albaxcordoba",
+        "hair": "Jesús de Paula @jesusdepaula",
+        "setDesign": "Isabel Adell @isadellc (asistente: Alborada MN @alboradamn)",
+        "talent": "Alice McGrath @alice_mcgrath_",
+        "talentAgency": "Uno Models @unomodels",
+        "production": "Saik Prod @saikprod",
+        "location": "Espacio La Candelaria @espacio_lacandelaria"
+      }
+    },
+    {
+      "title": "Numéro - Martina Cariddi",
+      "description": "Editorial para Numéro Netherlands con Martina Cariddi.",
+      "gallery": [
+        {
+          "file": "/assets/editorials/martina/1.webp",
+          "cover": true
+        },
+        {
+          "file": "/assets/editorials/martina/2.webp"
+        },
+        {
+          "file": "/assets/editorials/martina/3.webp"
+        },
+        {
+          "file": "/assets/editorials/martina/4.webp"
+        },
+        {
+          "file": "/assets/editorials/martina/5.webp"
+        },
+        {
+          "file": "/assets/editorials/martina/6.webp"
+        },
+        {
+          "file": "/assets/editorials/martina/7.webp"
+        },
+        {
+          "file": "/assets/editorials/martina/8.webp"
+        },
+        {
+          "file": "/assets/editorials/martina/9.webp"
+        },
+        {
+          "file": "/assets/editorials/martina/10.webp"
+        },
+        {
+          "file": "/assets/editorials/martina/11.webp"
+        },
+        {
+          "file": "/assets/editorials/martina/12.webp"
+        }
+      ],
+      "id": "martina",
+      "img": "/assets/editorials/martina/index.webp",
+      "img_alt": "Editorial Numéro - Martina Cariddi",
+      "cardSize": "normal",
+      "order": 3,
+      "role": "assistant-stylist",
+      "leadStylist": "Caterina Ospina",
+      "format": "editorial",
+      "credits": {
+        "photographer": "Sergio González @sergiognzalez",
+        "stylingTeam": "Verónica Faya @veronicafaya",
+        "makeup": "Cynthia de León @cynthiadeleon_",
+        "hair": "Jesús de Paula @jesusdepaula para Redken",
+        "talent": "Martina Cariddi @martinacariddi",
+        "production": "Saik Prod @saikprod",
+        "location": "Who Estudio @whoestudio"
+      }
+    },
+    {
+      "title": "Numéro - Isabeli Fontana",
+      "description": "Editorial para Numéro Netherlands con Isabeli Fontana.",
+      "gallery": [
+        {
+          "file": "/assets/editorials/isabeli/1.webp",
+          "cover": true
+        },
+        {
+          "file": "/assets/editorials/isabeli/2.webp"
+        },
+        {
+          "file": "/assets/editorials/isabeli/3.webp"
+        },
+        {
+          "file": "/assets/editorials/isabeli/4.webp"
+        },
+        {
+          "file": "/assets/editorials/isabeli/5.webp"
+        },
+        {
+          "file": "/assets/editorials/isabeli/6.webp"
+        },
+        {
+          "file": "/assets/editorials/isabeli/7.webp"
+        },
+        {
+          "file": "/assets/editorials/isabeli/8.webp"
+        },
+        {
+          "file": "/assets/editorials/isabeli/9.webp"
+        },
+        {
+          "file": "/assets/editorials/isabeli/10.webp"
+        },
+        {
+          "file": "/assets/editorials/isabeli/11.webp"
+        },
+        {
+          "file": "/assets/editorials/isabeli/12.webp"
+        },
+        {
+          "file": "/assets/editorials/isabeli/13.webp"
+        },
+        {
+          "file": "/assets/editorials/isabeli/14.webp"
+        }
+      ],
+      "id": "isabeli",
+      "img": "/assets/editorials/isabeli/index.webp",
+      "img_alt": "Editorial Numéro - Isabeli Fontana",
+      "cardSize": "normal",
+      "order": 4,
+      "role": "assistant-stylist",
+      "leadStylist": "Caterina Ospina",
+      "format": "editorial",
+      "credits": {
+        "photographer": "Juankr @juankr_",
+        "stylingTeam": "Gema Balsalobre @gemabalsalobre1",
+        "makeup": "Iván Gómez @ivangomez",
+        "hair": "Fernando Torrent @torrentfernando",
+        "setDesign": "Isabel Adell @isadellc",
+        "talent": "Isabeli Fontana @isabelifontana",
+        "talentAgency": "The Lions Management @thelionsmgmt",
+        "production": "Saik Prod @saikprod"
+      }
+    },
+    {
+      "title": "GQ - México",
+      "description": "Editorial para GQ México.",
+      "gallery": [
+        {
+          "file": "/assets/editorials/gq/1.webp"
+        },
+        {
+          "file": "/assets/editorials/gq/2.webp"
+        },
+        {
+          "file": "/assets/editorials/gq/3.webp",
+          "cover": true
+        }
+      ],
+      "id": "gq",
+      "img": "/assets/editorials/gq/index.webp",
+      "img_alt": "Editorial GQ México",
+      "cardSize": "normal",
+      "order": 5,
+      "role": "assistant-stylist",
+      "leadStylist": "Caterina Ospina",
+      "format": "editorial",
+      "credits": {
+        "photographer": "Juankr @juankr_",
+        "stylingTeam": "Verónica Faya @veronicaonfaya y Gema Balsalobre @gemabalsalobre1",
+        "muah": "Antonio Romero @antonioromeromakeup",
+        "talent": "Walid Fiher @w3lidd",
+        "production": "Saik Prod @saikprod"
+      }
+    },
+    {
+      "title": "Artego Magazine - Color Pop Garden",
+      "description": "Editorial «Color Pop Garden» para Artego Magazine.",
+      "gallery": [
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/1.webp",
+          "cover": true
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/2.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/3.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/4.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/5.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/6.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/7.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/8.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/9.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/10.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/11.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/12.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/13.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/14.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/15.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/16.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/17.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/18.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/19.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/20.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/21.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/22.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/23.webp"
+        },
+        {
+          "file": "/assets/editorials/artego-color-pop-garden/24.webp"
+        }
+      ],
+      "id": "artego-color-pop-garden",
+      "img": "/assets/editorials/artego-color-pop-garden/index.webp",
+      "img_alt": "Editorial Artego Magazine - Color Pop Garden",
+      "cardSize": "normal",
+      "order": 6,
+      "role": "lead-stylist",
+      "format": "editorial",
+      "credits": {
+        "photographer": "Alex Guerra @aleguerrax",
+        "talent": "Kamila Iskairova @iskairova_",
+        "muah": "Diego Vitaller @muagami_beauty"
+      }
+    },
+    {
+      "title": "pap magazine - The New Dandy",
+      "description": "Editorial «The New Dandy» para pap magazine.",
+      "gallery": [
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/1.webp",
+          "cover": true
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/2.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/3.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/4.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/5.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/6.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/7.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/8.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/9.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/10.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/11.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/12.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/13.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/14.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/15.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/16.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/17.webp"
+        },
+        {
+          "file": "/assets/editorials/pap-the-new-dandy/18.webp"
+        }
+      ],
+      "id": "pap-the-new-dandy",
+      "img": "/assets/editorials/pap-the-new-dandy/index.webp",
+      "img_alt": "Editorial pap magazine - The New Dandy",
+      "cardSize": "normal",
+      "order": 7,
+      "role": "lead-stylist",
+      "format": "editorial",
+      "credits": {
+        "photographer": "Fio Vicente @fio.vicente",
+        "talent": "Álvaro García Narváez @alvarogarcianarvaez",
+        "muah": "Diego Vitaller @muagami_beauty",
+        "talentAgency": "The Road Models @theroadmodels",
+        "video": "Camilo Andrés @camilo5p"
+      }
+    },
+    {
+      "title": "Folie Magazine - Always Love",
+      "description": "Editorial «Always Love» para Folie Magazine.",
+      "gallery": [
+        {
+          "file": "/assets/editorials/folie-always-love/1.webp",
+          "cover": true
+        },
+        {
+          "file": "/assets/editorials/folie-always-love/2.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-always-love/3.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-always-love/4.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-always-love/5.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-always-love/6.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-always-love/7.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-always-love/8.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-always-love/9.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-always-love/10.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-always-love/11.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-always-love/12.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-always-love/13.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-always-love/14.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-always-love/15.webp"
+        }
+      ],
+      "id": "folie-always-love",
+      "img": "/assets/editorials/folie-always-love/index.webp",
+      "img_alt": "Editorial Folie Magazine - Always Love",
+      "cardSize": "normal",
+      "order": 8,
+      "role": "lead-stylist",
+      "format": "editorial",
+      "credits": {
+        "photographer": "Leticia Díaz de la Morena @leticiadiazdelamorena",
+        "talent": "Charlotte Eva @charlotteeeva",
+        "muah": "Diego Vitaller @muagami_beauty"
+      }
+    },
+    {
+      "title": "Folie Magazine - Soft Tension",
+      "description": "Editorial «Soft Tension» para Folie Magazine.",
+      "gallery": [
+        {
+          "file": "/assets/editorials/folie-soft-tension/1.webp",
+          "cover": true
+        },
+        {
+          "file": "/assets/editorials/folie-soft-tension/2.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-soft-tension/3.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-soft-tension/4.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-soft-tension/5.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-soft-tension/6.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-soft-tension/7.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-soft-tension/8.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-soft-tension/9.webp"
+        },
+        {
+          "file": "/assets/editorials/folie-soft-tension/10.webp"
+        }
+      ],
+      "id": "folie-soft-tension",
+      "img": "/assets/editorials/folie-soft-tension/index.webp",
+      "img_alt": "Editorial Folie Magazine - Soft Tension",
+      "cardSize": "normal",
+      "order": 9,
+      "role": "lead-stylist",
+      "format": "editorial",
+      "credits": {
+        "photographer": "Diego G. @diego_v_photo",
+        "talent": "Luca Darblade @luca_darblade",
+        "muah": "Diego Vitaller @muagami_beauty",
+        "talentAgency": "Wanted Agency @wantedagency"
+      }
+    },
+    {
+      "title": "Mode Magazine - Isabel Arbós",
+      "description": "Editorial para Mode Magazine con Isabel Arbós.",
+      "gallery": [
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/28.webp",
+          "cover": true
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/2.webp"
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/1.webp",
+          "hidden": true,
+          "cover": false
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/4.webp"
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/5.webp",
+          "hidden": true
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/6.webp",
+          "hidden": true
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/7.webp"
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/8.webp"
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/9.webp",
+          "hidden": true
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/10.webp"
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/11.webp",
+          "hidden": true
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/12.webp"
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/13.webp"
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/14.webp"
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/15.webp"
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/16.webp",
+          "hidden": true
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/17.webp",
+          "hidden": true
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/18.webp",
+          "hidden": true
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/19.webp",
+          "hidden": true
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/20.webp"
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/21.webp",
+          "hidden": true
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/22.webp",
+          "hidden": true
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/23.webp",
+          "hidden": true
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/24.webp"
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/25.webp",
+          "hidden": true
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/26.webp",
+          "hidden": true
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/27.webp"
+        },
+        {
+          "file": "/assets/editorials/isabel-arbos-model-test/3.webp"
+        }
+      ],
+      "id": "isabel-arbos-model-test",
+      "img": "/assets/editorials/isabel-arbos-model-test/index.webp",
+      "img_alt": "Editorial Mode Magazine con Isabel Arbós",
+      "cardSize": "normal",
+      "order": 10,
+      "role": "lead-stylist",
+      "format": "editorial",
+      "credits": {
+        "photographer": "Paulo Herrera @pauloherrera.foto",
+        "talent": "Isabel Arbós @isabel_arbos",
+        "muah": "Diego Vitaller @muagami_beauty",
+        "talentAgency": "Six Management @sixmanagement.es"
+      }
+    },
+    {
+      "title": "Mode Magazine - Aminata Sarr",
+      "description": "Editorial para Mode Magazine con Aminata Sarr.",
+      "gallery": [
+        {
+          "file": "/assets/editorials/aminata/1.webp",
+          "cover": true
+        },
+        {
+          "file": "/assets/editorials/aminata/2.webp"
+        },
+        {
+          "file": "/assets/editorials/aminata/3.webp"
+        },
+        {
+          "file": "/assets/editorials/aminata/4.webp"
+        },
+        {
+          "file": "/assets/editorials/aminata/5.webp"
+        },
+        {
+          "file": "/assets/editorials/aminata/6.webp"
+        },
+        {
+          "file": "/assets/editorials/aminata/7.webp"
+        },
+        {
+          "file": "/assets/editorials/aminata/8.webp"
+        },
+        {
+          "file": "/assets/editorials/aminata/9.webp"
+        }
+      ],
+      "pin": "last",
+      "id": "aminata",
+      "img": "/assets/editorials/aminata/index.webp",
+      "img_alt": "Editorial Mode Magazine con Aminata Sarr",
+      "cardSize": "normal",
+      "order": 11,
+      "role": "lead-stylist",
+      "format": "editorial",
+      "credits": {
+        "photographer": "@shots_cv",
+        "talent": "Aminata Sarr @aminata.sr",
+        "hair": "@f0urt4zz",
+        "makeup": "@nermosu_"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Lo que hizo Luisa

**Ocultó 14 de las 28 fotos** de la editorial de Isabel Arbós, y movió tres de sitio (la portada al principio).

Verificado campo a campo contra `main`, no por el diff de texto: **ningún campo perdido, ningún proyecto desaparecido, ninguna foto fuera de la lista**. Solo marcadas como ocultas, que es reversible.

## Y el problema que encontró usándolo

Reordenar 28 fotos en el CMS era interminable: la lista de Sveltia mueve **de una en una con flechas** y solo enseña dos fotos a la vez. Reordenar es una tarea visual y ese componente la hacía imposible.

Entra una pantalla nueva en `/admin/ordenar/`:

- Las fotos del proyecto **en cuadrícula**, 24 a la vista en vez de 2.
- **Se reordenan arrastrando.**
- Los mismos dos interruptores por foto, ocultar y portada, con la portada como única.

### Por qué es más segura que el CMS para esta tarea

**Lee siempre la última versión de GitHub**, no una copia estática. Si trabajara sobre datos congelados, guardar revertiría lo que hubiera hecho otro entre medias.

**Si alguien guardó antes, GitHub rechaza el envío por el sha** y la pantalla pide recargar, en vez de pisar ese trabajo.

**No puede perder un campo.** Reescribe el JSON que leyó tocando solo `gallery`, así que el resto viaja intacto por construcción. En Sveltia eso depende de haber declarado los veinte campos correctamente; aquí no depende de nada.

### Verificado con un guardado real

Se ocultó una foto desde la pantalla, se guardó contra la rama, se revisó el commit resultante (**cero campos perdidos en los 11 proyectos del fichero, orden intacto**) y se revirtió. Ese commit de prueba y su reversión van en este PR.

## Reparto

Sveltia se queda para títulos, destacados y anclajes. Esta pantalla, solo para las fotos.

## Comprobado

`pnpm build` 117 páginas · `pnpm check:links` OK.

## Después de mergear

Sincronizar `contenido` con `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQ3fpT2Ck2fq8HqqJ5vtr