### PR TITLE
feat(cv): activar el enlace de descarga del CV

### DIFF
--- a/scripts/check-locale-links.mjs
+++ b/scripts/check-locale-links.mjs
@@ -15,7 +15,9 @@ const EN_DIR = path.join(DIST_DIR, "en");
 // completo ("/en" exacto o algo que empiece por "/en/"), nunca como prefijo de
 // caracteres — si no, "/encargos/".startsWith("/en") colaría en silencio. Por
 // eso "/en" exacto vive en ALLOWED_ABSOLUTE_EXACT y no aquí.
-const ALLOWED_ABSOLUTE_PREFIXES = ["/en/", "/_astro/", "/assets/"];
+// `/cv/` va aquí porque son ficheros, no páginas: el PDF inglés ya es el suyo
+// (luisa-benitez-cv-en.pdf) y no existe ni tiene sentido una copia bajo /en/.
+const ALLOWED_ABSOLUTE_PREFIXES = ["/en/", "/_astro/", "/assets/", "/cv/"];
 
 const ALLOWED_ABSOLUTE_EXACT = new Set([
 	"/en", // sin barra final, también válido (p.ej. enlace a la home EN)

--- a/src/components/CvDownloadLink.astro
+++ b/src/components/CvDownloadLink.astro
@@ -1,5 +1,6 @@
 ---
 // Vive en un componente propio (no inline por página) para centralizar `cvPath[locale]` (#39, no #10).
+import { conHuella } from "../lib/asset-version";
 import { profile } from "../data/profile";
 import { getLocaleFromUrl, getTranslation } from "../i18n";
 
@@ -9,8 +10,14 @@ const t = getTranslation(locale);
 
 {
 	profile.cvPath && (
-		<a class="cv" href={profile.cvPath[locale]}>
+		<a
+			class="cv"
+			href={conHuella(profile.cvPath[locale])}
+			target="_blank"
+			rel="noopener noreferrer"
+		>
 			{t.common.downloadCv} <span class="arrow" aria-hidden="true">&rarr;</span>
+			<span class="sr-only"> {t.common.newWindowHint}</span>
 		</a>
 	)
 }

--- a/src/data/profile.ts
+++ b/src/data/profile.ts
@@ -34,7 +34,10 @@ export const profile = {
 	 * prometer una descarga que daría 404. Al añadir los ficheros, rellenar:
 	 *   { es: '/cv/luisa-benitez-cv-es.pdf', en: '/cv/luisa-benitez-cv-en.pdf' }
 	 */
-	cvPath: undefined as { es: string; en: string } | undefined,
+	cvPath: {
+		es: '/cv/luisa-benitez-cv-es.pdf',
+		en: '/cv/luisa-benitez-cv-en.pdf',
+	} as { es: string; en: string } | undefined,
 
 	/**
 	 * TODO(H-5 / #12): "Fucking Young" fuera — es el único de la lista sin

--- a/src/lib/asset-version.ts
+++ b/src/lib/asset-version.ts
@@ -9,7 +9,7 @@ const cache = new Map<string, string>();
 // huella del contenido convierte cada cambio en una URL nueva, como ya hace Astro
 // con /_astro/. Sin esto hay que purgar Cloudflare a mano cada vez.
 export function conHuella(ruta: string): string {
-	if (!ruta.startsWith('/assets/')) return ruta;
+	if (!ruta.startsWith('/assets/') && !ruta.startsWith('/cv/')) return ruta;
 	if (cache.has(ruta)) return cache.get(ruta)!;
 
 	const fichero = join('public', ruta);


### PR DESCRIPTION
`cvPath` estaba en `undefined` a propósito: el CV tenía huecos sin rellenar y el componente no pintaba nada. Ya no los tiene, así que el enlace se enciende en Contacto, en los dos idiomas.

## Tres cosas que no eran obvias

**Va con huella de contenido**, para lo que hubo que ampliar `conHuella` a `/cv/`. Los PDF tienen nombre fijo, así que sin huella la caché seguiría sirviendo el viejo después de regenerarlos, que es exactamente lo que pasa cada vez que Luisa confirma un dato.

**Abre en pestaña nueva**, con el aviso para lectores de pantalla que ya usa el resto del sitio. Es un PDF, y perder el portfolio por abrirlo sería absurdo cuando el enlace vive en la página de contacto.

**`/cv/` entra en los prefijos permitidos del comprobador de enlaces.** Saltó al construir: marcaba el PDF inglés como un enlace que devuelve al visitante al sitio español. Falso positivo, porque son ficheros y no páginas: `luisa-benitez-cv-en.pdf` ya es la versión inglesa y no existe ni tiene sentido una copia bajo `/en/`.

## Comprobado

`pnpm build` 117 páginas · `pnpm check:links` OK · `pnpm cv` en verde.

El enlace resuelve en los dos idiomas y el PDF responde con `200 application/pdf`: en español apunta a `-es.pdf` y en inglés a `-en.pdf`.

## Después de mergear

Sincronizar `contenido` con `main`, que Luisa está trabajando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQ3fpT2Ck2fq8HqqJ5vtr