### PR TITLE
Luisa ordena sus cinco secciones

### DIFF
--- a/src/content/celebrities/celebrities.json
+++ b/src/content/celebrities/celebrities.json
@@ -1,6 +1,31 @@
 {
     "highlighted": [
         {
+            "id": "maica-premios-influencers",
+            "title": "Maica Benedicto - Influencers Awards",
+            "description": "Estilismo para Maica Benedicto en los Influencers Awards.",
+            "img": "/assets/celebrities/maica-premios-influencers/index.webp",
+            "img_alt": "Maica Benedicto en los Influencers Awards",
+            "cardSize": "normal",
+            "role": "lead-stylist",
+            "format": "event",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/maica-premios-influencers/2.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/celebrities/maica-premios-influencers/1.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-premios-influencers/3.webp"
+                },
+                {
+                    "file": "/assets/celebrities/maica-premios-influencers/4.webp"
+                }
+            ]
+        },
+        {
             "id": "maica-supervivientes",
             "title": "Maica Benedicto - Supervivientes",
             "description": "Estilismo para Maica Benedicto en su paso por el plató de Supervivientes.",
@@ -62,6 +87,26 @@
             ]
         },
         {
+            "id": "maica-telecinco",
+            "title": "Maica Benedicto - Telecinco",
+            "description": "Estilismo para Maica Benedicto en su aparición en Telecinco.",
+            "img": "/assets/celebrities/maica-telecinco/index.webp",
+            "img_alt": "Maica Benedicto en Telecinco",
+            "cardSize": "normal",
+            "role": "lead-stylist",
+            "format": "event",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/maica-telecinco/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/celebrities/maica-telecinco/video-1.mp4"
+                }
+            ]
+        },
+        {
             "id": "tania-deniz-coachella",
             "title": "Tania Deniz - Coachella",
             "description": "Estilismo para Tania Deniz durante Coachella.",
@@ -105,6 +150,22 @@
             ]
         },
         {
+            "id": "maica-benedicto-paris",
+            "title": "Maica Benedicto - París",
+            "description": "Estilismo para Maica Benedicto durante su estancia en París.",
+            "img": "/assets/celebrities/maica-benedicto-paris/1.webp",
+            "img_alt": "Maica Benedicto en París",
+            "cardSize": "normal",
+            "role": "lead-stylist",
+            "format": "event",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/maica-benedicto-paris/1.webp",
+                    "cover": true
+                }
+            ]
+        },
+        {
             "id": "ruth-basauri-coachella",
             "title": "Ruth Basauri - Coachella",
             "description": "Estilismo para Ruth Basauri durante Coachella.",
@@ -135,211 +196,6 @@
                 },
                 {
                     "file": "/assets/celebrities/ruth-basauri-coachella/4.webp"
-                }
-            ]
-        },
-        {
-            "id": "maica-premios-influencers",
-            "title": "Maica Benedicto - Influencers Awards",
-            "description": "Estilismo para Maica Benedicto en los Influencers Awards.",
-            "img": "/assets/celebrities/maica-premios-influencers/index.webp",
-            "img_alt": "Maica Benedicto en los Influencers Awards",
-            "cardSize": "normal",
-            "role": "lead-stylist",
-            "format": "event",
-            "gallery": [
-                {
-                    "file": "/assets/celebrities/maica-premios-influencers/2.webp",
-                    "cover": true
-                },
-                {
-                    "file": "/assets/celebrities/maica-premios-influencers/1.webp"
-                },
-                {
-                    "file": "/assets/celebrities/maica-premios-influencers/3.webp"
-                },
-                {
-                    "file": "/assets/celebrities/maica-premios-influencers/4.webp"
-                }
-            ]
-        },
-        {
-            "id": "alex-saint-malaga",
-            "title": "Alex Saint - Festival de Málaga",
-            "description": "Estilismo para Alex Saint en el Festival de Málaga.",
-            "img": "/assets/celebrities/alex-saint-malaga/index.webp",
-            "img_alt": "Alex Saint en el Festival de Málaga",
-            "cardSize": "normal",
-            "role": "lead-stylist",
-            "format": "event",
-            "gallery": [
-                {
-                    "file": "/assets/celebrities/alex-saint-malaga/1.webp"
-                },
-                {
-                    "file": "/assets/celebrities/alex-saint-malaga/2.webp"
-                },
-                {
-                    "file": "/assets/celebrities/alex-saint-malaga/3.webp",
-                    "cover": true
-                }
-            ]
-        },
-        {
-            "id": "maica-benedicto-paris",
-            "title": "Maica Benedicto - París",
-            "description": "Estilismo para Maica Benedicto durante su estancia en París.",
-            "img": "/assets/celebrities/maica-benedicto-paris/1.webp",
-            "img_alt": "Maica Benedicto en París",
-            "cardSize": "normal",
-            "role": "lead-stylist",
-            "format": "event",
-            "gallery": [
-                {
-                    "file": "/assets/celebrities/maica-benedicto-paris/1.webp",
-                    "cover": true
-                }
-            ]
-        },
-        {
-            "id": "maica-telecinco",
-            "title": "Maica Benedicto - Telecinco",
-            "description": "Estilismo para Maica Benedicto en su aparición en Telecinco.",
-            "img": "/assets/celebrities/maica-telecinco/index.webp",
-            "img_alt": "Maica Benedicto en Telecinco",
-            "cardSize": "normal",
-            "role": "lead-stylist",
-            "format": "event",
-            "gallery": [
-                {
-                    "file": "/assets/celebrities/maica-telecinco/index.webp",
-                    "hidden": true,
-                    "cover": true
-                },
-                {
-                    "file": "/assets/celebrities/maica-telecinco/video-1.mp4"
-                }
-            ]
-        },
-        {
-            "id": "miguel-herran",
-            "title": "Miguel Herrán - Chaumet",
-            "description": "Estilismo para evento de presentación de colección de joyería de Chaumet by Nature.",
-            "img": "/assets/celebrities/miguel-herran/index.webp",
-            "img_alt": "Miguel Herrán en evento Chaumet",
-            "cardSize": "normal",
-            "role": "assistant-stylist",
-            "format": "event",
-            "leadStylist": "Caterina Ospina",
-            "gallery": [
-                {
-                    "file": "/assets/celebrities/miguel-herran/index.webp",
-                    "hidden": true,
-                    "cover": true
-                },
-                {
-                    "file": "/assets/celebrities/miguel-herran/1.webp"
-                },
-                {
-                    "file": "/assets/celebrities/miguel-herran/2.webp"
-                }
-            ]
-        },
-        {
-            "id": "zara",
-            "title": "Zara Larsson - Amaze Festival",
-            "description": "Estilismo para concierto de Zara Larsson y sus bailarinas en Amaze Festival.",
-            "img": "/assets/celebrities/zara/index.webp",
-            "img_alt": "Zara Larsson en evento Amaze Festival",
-            "cardSize": "normal",
-            "role": "assistant-stylist",
-            "format": "event",
-            "leadStylist": "Caterina Ospina",
-            "gallery": [
-                {
-                    "file": "/assets/celebrities/zara/1.webp"
-                },
-                {
-                    "file": "/assets/celebrities/zara/2.webp"
-                },
-                {
-                    "file": "/assets/celebrities/zara/3.webp"
-                },
-                {
-                    "file": "/assets/celebrities/zara/4.webp",
-                    "cover": true
-                },
-                {
-                    "file": "/assets/celebrities/zara/5.webp"
-                },
-                {
-                    "file": "/assets/celebrities/zara/6.webp"
-                },
-                {
-                    "file": "/assets/celebrities/zara/7.webp"
-                },
-                {
-                    "file": "/assets/celebrities/zara/8.webp"
-                },
-                {
-                    "file": "/assets/celebrities/zara/9.webp"
-                },
-                {
-                    "file": "/assets/celebrities/zara/10.webp"
-                },
-                {
-                    "file": "/assets/celebrities/zara/11.webp"
-                }
-            ]
-        },
-        {
-            "id": "aitana",
-            "title": "Aitana - YSL",
-            "description": "Estilismo para Aitana evento YSL Beauty.",
-            "img": "/assets/celebrities/aitana/index.webp",
-            "img_alt": "Aitana en evento YSL Beauty",
-            "cardSize": "normal",
-            "role": "assistant-stylist",
-            "format": "event",
-            "leadStylist": "Caterina Ospina",
-            "gallery": [
-                {
-                    "file": "/assets/celebrities/aitana/index.webp",
-                    "hidden": true
-                },
-                {
-                    "file": "/assets/celebrities/aitana/1.webp"
-                },
-                {
-                    "file": "/assets/celebrities/aitana/2.webp"
-                },
-                {
-                    "file": "/assets/celebrities/aitana/3.webp",
-                    "cover": true
-                }
-            ]
-        },
-        {
-            "id": "aron-piper",
-            "title": "Aron Piper - YSL",
-            "description": "Estilismo para Aron Piper evento YSL Beauty.",
-            "img": "/assets/celebrities/aron-piper/index.webp",
-            "img_alt": "Aron Piper en evento YSL Beauty",
-            "cardSize": "normal",
-            "role": "assistant-stylist",
-            "format": "event",
-            "leadStylist": "Caterina Ospina",
-            "gallery": [
-                {
-                    "file": "/assets/celebrities/aron-piper/index.webp",
-                    "hidden": true,
-                    "cover": true
-                },
-                {
-                    "file": "/assets/celebrities/aron-piper/1.webp"
-                },
-                {
-                    "file": "/assets/celebrities/aron-piper/2.webp"
                 }
             ]
         },
@@ -394,6 +250,102 @@
             ]
         },
         {
+            "id": "aitana",
+            "title": "Aitana - YSL",
+            "description": "Estilismo para Aitana evento YSL Beauty.",
+            "img": "/assets/celebrities/aitana/index.webp",
+            "img_alt": "Aitana en evento YSL Beauty",
+            "cardSize": "normal",
+            "role": "assistant-stylist",
+            "format": "event",
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/aitana/index.webp",
+                    "hidden": true
+                },
+                {
+                    "file": "/assets/celebrities/aitana/1.webp"
+                },
+                {
+                    "file": "/assets/celebrities/aitana/2.webp"
+                },
+                {
+                    "file": "/assets/celebrities/aitana/3.webp",
+                    "cover": true
+                }
+            ]
+        },
+        {
+            "id": "zara",
+            "title": "Zara Larsson - Amaze Festival",
+            "description": "Estilismo para concierto de Zara Larsson y sus bailarinas en Amaze Festival.",
+            "img": "/assets/celebrities/zara/index.webp",
+            "img_alt": "Zara Larsson en evento Amaze Festival",
+            "cardSize": "normal",
+            "role": "assistant-stylist",
+            "format": "event",
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/zara/1.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/2.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/3.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/4.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/celebrities/zara/5.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/6.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/7.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/8.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/9.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/10.webp"
+                },
+                {
+                    "file": "/assets/celebrities/zara/11.webp"
+                }
+            ]
+        },
+        {
+            "id": "alex-saint-malaga",
+            "title": "Alex Saint - Festival de Málaga",
+            "description": "Estilismo para Alex Saint en el Festival de Málaga.",
+            "img": "/assets/celebrities/alex-saint-malaga/index.webp",
+            "img_alt": "Alex Saint en el Festival de Málaga",
+            "cardSize": "normal",
+            "role": "lead-stylist",
+            "format": "event",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/alex-saint-malaga/1.webp"
+                },
+                {
+                    "file": "/assets/celebrities/alex-saint-malaga/2.webp"
+                },
+                {
+                    "file": "/assets/celebrities/alex-saint-malaga/3.webp",
+                    "cover": true
+                }
+            ]
+        },
+        {
             "id": "maria-pombo-netflix",
             "title": "María Pombo - Netflix",
             "description": "Estilismo para María Pombo en evento de Netflix.",
@@ -410,6 +362,54 @@
                 },
                 {
                     "file": "/assets/celebrities/maria-pombo-netflix/video-1.mp4"
+                }
+            ]
+        },
+        {
+            "id": "miguel-herran",
+            "title": "Miguel Herrán - Chaumet",
+            "description": "Estilismo para evento de presentación de colección de joyería de Chaumet by Nature.",
+            "img": "/assets/celebrities/miguel-herran/index.webp",
+            "img_alt": "Miguel Herrán en evento Chaumet",
+            "cardSize": "normal",
+            "role": "assistant-stylist",
+            "format": "event",
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/miguel-herran/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/celebrities/miguel-herran/1.webp"
+                },
+                {
+                    "file": "/assets/celebrities/miguel-herran/2.webp"
+                }
+            ]
+        },
+        {
+            "id": "aron-piper",
+            "title": "Aron Piper - YSL",
+            "description": "Estilismo para Aron Piper evento YSL Beauty.",
+            "img": "/assets/celebrities/aron-piper/index.webp",
+            "img_alt": "Aron Piper en evento YSL Beauty",
+            "cardSize": "normal",
+            "role": "assistant-stylist",
+            "format": "event",
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/celebrities/aron-piper/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/celebrities/aron-piper/1.webp"
+                },
+                {
+                    "file": "/assets/celebrities/aron-piper/2.webp"
                 }
             ]
         }

--- a/src/content/celebrities/celebrities.json
+++ b/src/content/celebrities/celebrities.json
@@ -23,8 +23,7 @@
                 {
                     "file": "/assets/celebrities/maica-premios-influencers/4.webp"
                 }
-            ],
-            "featured": true
+            ]
         },
         {
             "id": "maica-supervivientes",
@@ -105,7 +104,8 @@
                 {
                     "file": "/assets/celebrities/maica-telecinco/video-1.mp4"
                 }
-            ]
+            ],
+            "featured": true
         },
         {
             "id": "tania-deniz-coachella",

--- a/src/content/celebrities/celebrities.json
+++ b/src/content/celebrities/celebrities.json
@@ -104,8 +104,7 @@
                 {
                     "file": "/assets/celebrities/maica-telecinco/video-1.mp4"
                 }
-            ],
-            "featured": true
+            ]
         },
         {
             "id": "tania-deniz-coachella",
@@ -275,7 +274,8 @@
                     "file": "/assets/celebrities/aitana/3.webp",
                     "cover": true
                 }
-            ]
+            ],
+            "featured": true
         },
         {
             "id": "zara",

--- a/src/content/celebrities/celebrities.json
+++ b/src/content/celebrities/celebrities.json
@@ -23,7 +23,8 @@
                 {
                     "file": "/assets/celebrities/maica-premios-influencers/4.webp"
                 }
-            ]
+            ],
+            "featured": true
         },
         {
             "id": "maica-supervivientes",

--- a/src/content/editorials/editorials.json
+++ b/src/content/editorials/editorials.json
@@ -130,7 +130,8 @@
                 "muah": "Diego Vitaller @muagami_beauty",
                 "talentAgency": "The Road Models @theroadmodels",
                 "video": "Camilo Andrés @camilo5p"
-            }
+            },
+            "featured": true
         },
         {
             "title": "Artego Magazine - Color Pop Garden",

--- a/src/content/editorials/editorials.json
+++ b/src/content/editorials/editorials.json
@@ -59,6 +59,80 @@
             }
         },
         {
+            "title": "pap magazine - The New Dandy",
+            "description": "Editorial «The New Dandy» para pap magazine.",
+            "gallery": [
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/1.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/5.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/6.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/10.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/11.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/12.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/13.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/14.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/15.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/16.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/17.webp"
+                },
+                {
+                    "file": "/assets/editorials/pap-the-new-dandy/18.webp"
+                }
+            ],
+            "id": "pap-the-new-dandy",
+            "img": "/assets/editorials/pap-the-new-dandy/index.webp",
+            "img_alt": "Editorial pap magazine - The New Dandy",
+            "cardSize": "normal",
+            "role": "lead-stylist",
+            "format": "editorial",
+            "credits": {
+                "photographer": "Fio Vicente @fio.vicente",
+                "talent": "Álvaro García Narváez @alvarogarcianarvaez",
+                "muah": "Diego Vitaller @muagami_beauty",
+                "talentAgency": "The Road Models @theroadmodels",
+                "video": "Camilo Andrés @camilo5p"
+            }
+        },
+        {
             "title": "Artego Magazine - Color Pop Garden",
             "description": "Editorial «Color Pop Garden» para Artego Magazine.",
             "gallery": [
@@ -155,77 +229,53 @@
             }
         },
         {
-            "title": "pap magazine - The New Dandy",
-            "description": "Editorial «The New Dandy» para pap magazine.",
+            "title": "Folie Magazine - Soft Tension",
+            "description": "Editorial «Soft Tension» para Folie Magazine.",
             "gallery": [
                 {
-                    "file": "/assets/editorials/pap-the-new-dandy/1.webp",
+                    "file": "/assets/editorials/folie-soft-tension/2.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/3.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/4.webp"
+                },
+                {
+                    "file": "/assets/editorials/folie-soft-tension/5.webp",
                     "cover": true
                 },
                 {
-                    "file": "/assets/editorials/pap-the-new-dandy/2.webp"
+                    "file": "/assets/editorials/folie-soft-tension/6.webp"
                 },
                 {
-                    "file": "/assets/editorials/pap-the-new-dandy/3.webp"
+                    "file": "/assets/editorials/folie-soft-tension/7.webp"
                 },
                 {
-                    "file": "/assets/editorials/pap-the-new-dandy/4.webp"
+                    "file": "/assets/editorials/folie-soft-tension/8.webp"
                 },
                 {
-                    "file": "/assets/editorials/pap-the-new-dandy/5.webp"
+                    "file": "/assets/editorials/folie-soft-tension/9.webp"
                 },
                 {
-                    "file": "/assets/editorials/pap-the-new-dandy/6.webp"
+                    "file": "/assets/editorials/folie-soft-tension/10.webp",
+                    "hidden": true
                 },
                 {
-                    "file": "/assets/editorials/pap-the-new-dandy/7.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/8.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/9.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/10.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/11.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/12.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/13.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/14.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/15.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/16.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/17.webp"
-                },
-                {
-                    "file": "/assets/editorials/pap-the-new-dandy/18.webp"
+                    "file": "/assets/editorials/folie-soft-tension/1.webp"
                 }
             ],
-            "id": "pap-the-new-dandy",
-            "img": "/assets/editorials/pap-the-new-dandy/index.webp",
-            "img_alt": "Editorial pap magazine - The New Dandy",
+            "id": "folie-soft-tension",
+            "img": "/assets/editorials/folie-soft-tension/index.webp",
+            "img_alt": "Editorial Folie Magazine - Soft Tension",
             "cardSize": "normal",
             "role": "lead-stylist",
             "format": "editorial",
             "credits": {
-                "photographer": "Fio Vicente @fio.vicente",
-                "talent": "Álvaro García Narváez @alvarogarcianarvaez",
+                "photographer": "Diego G. @diego_v_photo",
+                "talent": "Luca Darblade @luca_darblade",
                 "muah": "Diego Vitaller @muagami_beauty",
-                "talentAgency": "The Road Models @theroadmodels",
-                "video": "Camilo Andrés @camilo5p"
+                "talentAgency": "Wanted Agency @wantedagency"
             }
         },
         {
@@ -292,53 +342,54 @@
             }
         },
         {
-            "title": "Folie Magazine - Soft Tension",
-            "description": "Editorial «Soft Tension» para Folie Magazine.",
+            "title": "GQ - México",
+            "description": "Editorial para GQ México.",
             "gallery": [
                 {
-                    "file": "/assets/editorials/folie-soft-tension/2.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-soft-tension/3.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-soft-tension/4.webp"
-                },
-                {
-                    "file": "/assets/editorials/folie-soft-tension/5.webp",
+                    "file": "/assets/editorials/gq/1.webp",
                     "cover": true
                 },
                 {
-                    "file": "/assets/editorials/folie-soft-tension/6.webp"
+                    "file": "/assets/editorials/gq/2.webp"
                 },
                 {
-                    "file": "/assets/editorials/folie-soft-tension/7.webp"
+                    "file": "/assets/editorials/gq/3.webp"
                 },
                 {
-                    "file": "/assets/editorials/folie-soft-tension/8.webp"
+                    "file": "/assets/editorials/gq/4.webp"
                 },
                 {
-                    "file": "/assets/editorials/folie-soft-tension/9.webp"
+                    "file": "/assets/editorials/gq/5.webp"
                 },
                 {
-                    "file": "/assets/editorials/folie-soft-tension/10.webp",
-                    "hidden": true
+                    "file": "/assets/editorials/gq/6.webp"
                 },
                 {
-                    "file": "/assets/editorials/folie-soft-tension/1.webp"
+                    "file": "/assets/editorials/gq/7.webp"
+                },
+                {
+                    "file": "/assets/editorials/gq/8.webp"
+                },
+                {
+                    "file": "/assets/editorials/gq/9.webp"
+                },
+                {
+                    "file": "/assets/editorials/gq/10.webp"
                 }
             ],
-            "id": "folie-soft-tension",
-            "img": "/assets/editorials/folie-soft-tension/index.webp",
-            "img_alt": "Editorial Folie Magazine - Soft Tension",
+            "id": "gq",
+            "img": "/assets/editorials/gq/index.webp",
+            "img_alt": "Editorial GQ México",
             "cardSize": "normal",
-            "role": "lead-stylist",
+            "role": "assistant-stylist",
+            "leadStylist": "Caterina Ospina",
             "format": "editorial",
             "credits": {
-                "photographer": "Diego G. @diego_v_photo",
-                "talent": "Luca Darblade @luca_darblade",
-                "muah": "Diego Vitaller @muagami_beauty",
-                "talentAgency": "Wanted Agency @wantedagency"
+                "photographer": "Juankr @juankr_",
+                "stylingTeam": "Verónica Faya @veronicaonfaya y Gema Balsalobre @gemabalsalobre1",
+                "muah": "Antonio Romero @antonioromeromakeup",
+                "talent": "Walid Fiher @w3lidd",
+                "production": "Saik Prod @saikprod"
             }
         },
         {
@@ -634,57 +685,6 @@
                 "setDesign": "Isabel Adell @isadellc",
                 "talent": "Isabeli Fontana @isabelifontana",
                 "talentAgency": "The Lions Management @thelionsmgmt",
-                "production": "Saik Prod @saikprod"
-            }
-        },
-        {
-            "title": "GQ - México",
-            "description": "Editorial para GQ México.",
-            "gallery": [
-                {
-                    "file": "/assets/editorials/gq/1.webp",
-                    "cover": true
-                },
-                {
-                    "file": "/assets/editorials/gq/2.webp"
-                },
-                {
-                    "file": "/assets/editorials/gq/3.webp"
-                },
-                {
-                    "file": "/assets/editorials/gq/4.webp"
-                },
-                {
-                    "file": "/assets/editorials/gq/5.webp"
-                },
-                {
-                    "file": "/assets/editorials/gq/6.webp"
-                },
-                {
-                    "file": "/assets/editorials/gq/7.webp"
-                },
-                {
-                    "file": "/assets/editorials/gq/8.webp"
-                },
-                {
-                    "file": "/assets/editorials/gq/9.webp"
-                },
-                {
-                    "file": "/assets/editorials/gq/10.webp"
-                }
-            ],
-            "id": "gq",
-            "img": "/assets/editorials/gq/index.webp",
-            "img_alt": "Editorial GQ México",
-            "cardSize": "normal",
-            "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina",
-            "format": "editorial",
-            "credits": {
-                "photographer": "Juankr @juankr_",
-                "stylingTeam": "Verónica Faya @veronicaonfaya y Gema Balsalobre @gemabalsalobre1",
-                "muah": "Antonio Romero @antonioromeromakeup",
-                "talent": "Walid Fiher @w3lidd",
                 "production": "Saik Prod @saikprod"
             }
         },

--- a/src/content/publicity/publicity.json
+++ b/src/content/publicity/publicity.json
@@ -126,25 +126,6 @@
             ]
         },
         {
-            "id": "ysl-aitana",
-            "title": "YSL - Aitana",
-            "description": "Campaña para YSL con Aitana.",
-            "img_alt": "Campaña YSL Aitana",
-            "cardSize": "normal",
-            "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina",
-            "gallery": [
-                {
-                    "file": "/assets/publicity/ysl-aitana/index.webp",
-                    "hidden": true,
-                    "cover": true
-                },
-                {
-                    "file": "/assets/publicity/ysl-aitana/video-1.mp4"
-                }
-            ]
-        },
-        {
             "id": "agatha-paris-maria-pombo",
             "title": "Agatha Paris - María Pombo",
             "description": "Campaña para Agatha Paris con María Pombo.",
@@ -166,6 +147,63 @@
                 },
                 {
                     "file": "/assets/publicity/agatha-paris-maria-pombo/video-2.mp4"
+                }
+            ]
+        },
+        {
+            "id": "ysl-aitana",
+            "title": "YSL - Aitana",
+            "description": "Campaña para YSL con Aitana.",
+            "img_alt": "Campaña YSL Aitana",
+            "cardSize": "normal",
+            "role": "assistant-stylist",
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/publicity/ysl-aitana/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/ysl-aitana/video-1.mp4"
+                }
+            ]
+        },
+        {
+            "id": "kerastase-nicole-wallace",
+            "title": "Kérastase - Nicole Wallace",
+            "description": "Campaña para Kérastase con Nicole Wallace.",
+            "img_alt": "Campaña Kérastase Nicole Wallace",
+            "cardSize": "normal",
+            "role": "assistant-stylist",
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/publicity/kerastase-nicole-wallace/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/kerastase-nicole-wallace/kerastase-nicole-wallace.mp4"
+                }
+            ]
+        },
+        {
+            "id": "kerastase-lola-lolita",
+            "title": "Kérastase - Lola Lolita",
+            "description": "Campaña para Kérastase con Lola Lolita.",
+            "img_alt": "Campaña Kérastase Lola Lolita",
+            "cardSize": "normal",
+            "role": "assistant-stylist",
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/publicity/kerastase-lola-lolita/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/kerastase-lola-lolita/kerastase-lola-lolita.mp4"
                 }
             ]
         },
@@ -195,63 +233,6 @@
                 },
                 {
                     "file": "/assets/publicity/gdh-jesus-de-paula/video-4.mp4"
-                }
-            ]
-        },
-        {
-            "id": "kerastase",
-            "title": "Kérastase",
-            "description": "Campaña para Kérastase.",
-            "img_alt": "Campaña Kérastase",
-            "cardSize": "normal",
-            "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina",
-            "gallery": [
-                {
-                    "file": "/assets/publicity/kerastase/index.webp",
-                    "hidden": true,
-                    "cover": true
-                },
-                {
-                    "file": "/assets/publicity/kerastase/video-1.mp4"
-                }
-            ]
-        },
-        {
-            "id": "kerastase-lola-lolita",
-            "title": "Kérastase - Lola Lolita",
-            "description": "Campaña para Kérastase con Lola Lolita.",
-            "img_alt": "Campaña Kérastase Lola Lolita",
-            "cardSize": "normal",
-            "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina",
-            "gallery": [
-                {
-                    "file": "/assets/publicity/kerastase-lola-lolita/index.webp",
-                    "hidden": true,
-                    "cover": true
-                },
-                {
-                    "file": "/assets/publicity/kerastase-lola-lolita/kerastase-lola-lolita.mp4"
-                }
-            ]
-        },
-        {
-            "id": "kerastase-nicole-wallace",
-            "title": "Kérastase - Nicole Wallace",
-            "description": "Campaña para Kérastase con Nicole Wallace.",
-            "img_alt": "Campaña Kérastase Nicole Wallace",
-            "cardSize": "normal",
-            "role": "assistant-stylist",
-            "leadStylist": "Caterina Ospina",
-            "gallery": [
-                {
-                    "file": "/assets/publicity/kerastase-nicole-wallace/index.webp",
-                    "hidden": true,
-                    "cover": true
-                },
-                {
-                    "file": "/assets/publicity/kerastase-nicole-wallace/kerastase-nicole-wallace.mp4"
                 }
             ]
         },
@@ -303,6 +284,25 @@
                 },
                 {
                     "file": "/assets/publicity/vogue-spain-maria-pombo/vogue-spain-maria-pombo.mp4"
+                }
+            ]
+        },
+        {
+            "id": "kerastase",
+            "title": "Kérastase",
+            "description": "Campaña para Kérastase.",
+            "img_alt": "Campaña Kérastase",
+            "cardSize": "normal",
+            "role": "assistant-stylist",
+            "leadStylist": "Caterina Ospina",
+            "gallery": [
+                {
+                    "file": "/assets/publicity/kerastase/index.webp",
+                    "hidden": true,
+                    "cover": true
+                },
+                {
+                    "file": "/assets/publicity/kerastase/video-1.mp4"
                 }
             ]
         }

--- a/src/content/publicity/publicity.json
+++ b/src/content/publicity/publicity.json
@@ -42,7 +42,8 @@
                 {
                     "file": "/assets/publicity/alaniz-maria-pombo/video-3.mp4"
                 }
-            ]
+            ],
+            "featured": true
         },
         {
             "id": "bruno-magli",

--- a/src/content/runway/runway.json
+++ b/src/content/runway/runway.json
@@ -72,33 +72,6 @@
             ]
         },
         {
-            "id": "angel-schlesser-2024",
-            "title": "Colección Primavera/Verano 24 Intersticio - Ángel Schlesser",
-            "description": "Colección Primavera/Verano 24 «Intersticio» de Ángel Schlesser en Mercedes-Benz Fashion Week Madrid.",
-            "img": "/assets/runway/angel-schlesser-2024/1.webp",
-            "img_alt": "Colección Ángel Schlesser Primavera/Verano 24 Intersticio",
-            "cardSize": "normal",
-            "role": "wardrobe-assistant",
-            "gallery": [
-                {
-                    "file": "/assets/runway/angel-schlesser-2024/1.webp"
-                },
-                {
-                    "file": "/assets/runway/angel-schlesser-2024/2.webp",
-                    "cover": true
-                },
-                {
-                    "file": "/assets/runway/angel-schlesser-2024/3.webp"
-                },
-                {
-                    "file": "/assets/runway/angel-schlesser-2024/video-1.mp4"
-                },
-                {
-                    "file": "/assets/runway/angel-schlesser-2024/video-2.mp4"
-                }
-            ]
-        },
-        {
             "id": "angel-schlesser-2023",
             "title": "Otoño/Invierno 23.Femme - Ángel Schlesser",
             "description": "Desfile Otoño/Invierno 23.Femme de Ángel Schlesser en el programa OFF de Mercedes-Benz Fashion Week Madrid, en el Espacio Larra.",
@@ -122,6 +95,33 @@
                 },
                 {
                     "file": "/assets/runway/angel-schlesser-2023/video-1.mp4"
+                }
+            ]
+        },
+        {
+            "id": "angel-schlesser-2024",
+            "title": "Colección Primavera/Verano 24 Intersticio - Ángel Schlesser",
+            "description": "Colección Primavera/Verano 24 «Intersticio» de Ángel Schlesser en Mercedes-Benz Fashion Week Madrid.",
+            "img": "/assets/runway/angel-schlesser-2024/1.webp",
+            "img_alt": "Colección Ángel Schlesser Primavera/Verano 24 Intersticio",
+            "cardSize": "normal",
+            "role": "wardrobe-assistant",
+            "gallery": [
+                {
+                    "file": "/assets/runway/angel-schlesser-2024/1.webp"
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2024/2.webp",
+                    "cover": true
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2024/3.webp"
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2024/video-1.mp4"
+                },
+                {
+                    "file": "/assets/runway/angel-schlesser-2024/video-2.mp4"
                 }
             ]
         }


### PR DESCRIPTION
Primera tanda usando el modo **«Orden de los proyectos»**. Nueve guardados en cuatro secciones.

Comparado campo a campo contra `main`: **cero campos perdidos, cero proyectos desaparecidos, cero fotos fuera de las listas**. Solo cambia el orden, que es exactamente lo que se pretendía.

## Cómo quedan las secciones

**Editoriales**: sube pap magazine al segundo puesto y agrupa los tres Numéro al final, con Vogue Adria abriendo y Mode Magazine cerrando.

**Campañas**: Alaniz, Bruno Magli y Prime Video abren; Kérastase pasa al final.

**Celebridades**: reordenada casi entera. Abren los tres de Maica Benedicto y cierran Miguel Herrán y Aron Piper.

**Runway**: intercambia los dos Ángel Schlesser del final.

## La home ya la decide ella

**Ha marcado cuatro proyectos como destacados**: pap magazine, Alaniz, Prime Video y Aitana. Así que el relleno por turnos ya no interviene: los cuatro que salen son los cuatro que eligió.

Es justo lo que buscábamos al quitar las reglas automáticas. La portada del sitio pasa de ser un efecto secundario del algoritmo a una decisión suya.

## Comprobado

`pnpm build` 129 páginas · `pnpm check:links` OK · `pnpm verify:portadas` 79 derivadas correctas.

Las variantes de tarjeta y las imágenes sociales se regeneraron y **salieron idénticas**: al reordenar proyectos las portadas no cambian, así que no hay nada que rehacer. La comprobación de frescura las rehace igualmente porque el JSON cambió de fecha; es trabajo de más, no un error, y solo ocurre al ejecutarlas a mano.

## Después de mergear

Sincronizar `contenido` con `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQ3fpT2Ck2fq8HqqJ5vtr