### PR TITLE
fix(visor): el primer play no respondía en escritorio

### DIFF
--- a/src/components/GalleryViewer.astro
+++ b/src/components/GalleryViewer.astro
@@ -44,6 +44,11 @@ const media = await Promise.all(
 							muted
 							playsinline
 							controls
+							{/*
+							 * Sigue en `none` para no descargar vídeo a quien no lo abre:
+							 * medido, `metadata` se traía los 2,5 MB enteros. La carga la
+							 * fuerza `load()` al abrir el visor, que es cuando hace falta.
+							 */}
 							preload="none"
 							data-viewer-video
 						/>
@@ -380,8 +385,19 @@ const media = await Promise.all(
 			dialog.querySelectorAll<HTMLVideoElement>("[data-viewer-video]").forEach((v) => {
 				if (v !== videoActivo()) v.pause();
 			});
+			// `play()` en los dos tamaños, y `load()` solo si el navegador lo
+			// rechaza. Con `preload="none"` Safari no descargaba nada por su cuenta:
+			// el vídeo se quedaba en readyState 0, los mandos nativos salían sin
+			// duración y el primer clic no hacía nada. Al recargar parecía
+			// arreglado, pero era la caché del intento anterior.
+			//
+			// El respaldo va en el `catch` y no antes: `load()` reinicia el vídeo y
+			// cancelaría el `play()` que sí iba a funcionar (medido).
+			const activo = videoActivo();
+			activo?.play().catch(() => {
+				if (activo.readyState === 0) activo.load();
+			});
 			if (!movil.matches) return;
-			videoActivo()?.play().catch(() => {});
 			refrescarProgresoSiExiste();
 		}
 


### PR DESCRIPTION
En escritorio los vídeos no arrancaban y los mandos nativos no hacían nada. Al recargar sí funcionaba, y **eso último despistaba**: no era el recargar, era la caché del intento anterior.

## La pista estaba en la captura

Los mandos salían con **«0:00» y sin duración total**. Eso significa `readyState 0`: el vídeo no había cargado ni su cabecera.

Con `preload="none"` Safari **no descarga nada por su cuenta**, así que el `play()` que lanza el observer se rechazaba, y el `.catch(() => {})` se tragaba el fallo sin dejar rastro en consola.

## El arreglo

`play()` corre ahora en los dos tamaños, no solo en móvil, y **`load()` queda como respaldo dentro del `catch`**.

Ese orden importa y está medido: llamar a `load()` antes reinicia el vídeo y **cancela el `play()` que sí iba a funcionar** — al probarlo así el vídeo se quedaba pausado.

## Lo que se descartó

Subir el `preload` a `metadata` parecía la solución obvia. **Medido: Chromium se traía los 2,5 MB enteros** al cargar la página, aunque nadie abriera el visor.

Sigue en `none`: **0 KB hasta que se abre el visor**, y ahí ya carga.

## Honestidad sobre la verificación

**No está probado en Safari**: en este entorno solo hay Chromium. Lo que sí está medido es que el vídeo ya no depende de un `play()` que puede rechazarse en silencio, y que la duración aparece en cuanto se abre.

Conviene que David lo pruebe en su Mac tal cual lo tiene.

## Comprobado

`pnpm verify:viewer` en verde · `pnpm build` 129 páginas · `pnpm check:links` OK · `pnpm verify:videos` 42 correctos · `pnpm verify:portadas` 79 correctas · probado llegando por navegación (no recarga) y con «reducir movimiento» activado.

## Después de mergear

Sincronizar `contenido` con `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQ3fpT2Ck2fq8HqqJ5vtr