### PR TITLE
fix(cabecera): la sección se partía en dos líneas en móvil

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -65,7 +65,7 @@ const activeLink = textLinks.find((link) => isCurrentPage(link.href));
 				{
 					activeLink && activeLink.href !== homeHref && (
 						<span class="mobile-page-label">
-							| {activeLink.label}
+							{activeLink.label}
 						</span>
 					)
 				}
@@ -269,7 +269,27 @@ const activeLink = textLinks.find((link) => isCurrentPage(link.href));
 		font-size: var(--text-md);
 		color: var(--gray-100);
 		font-weight: 400;
-		margin-left: 0.25rem;
+		/*
+		 * El separador es un borde y no el carácter «|» que había: como texto se
+		 * quedaba solo al final de un renglón y la sección bajaba a la siguiente
+		 * («| ⏎ Celebridades» en un iPhone). Además un lector de pantalla lo leía
+		 * como «barra vertical».
+		 */
+		margin-left: 0.5rem;
+		padding-left: 0.5rem;
+		border-left: 1px solid currentColor;
+		/*
+		 * Sin partir y sin encogerse: el nombre y la sección comparten fila, y
+		 * dejando que el flex la comprimiera salía «Celebrida…». El nombre ya se
+		 * reparte en dos renglones, así que el hueco que necesita esto es suyo.
+		 * Medido a 320px, el ancho más estrecho que se maneja: quedan 8px hasta
+		 * el botón del menú.
+		 */
+		white-space: nowrap;
+		flex-shrink: 0;
+		/* Red de seguridad por si algún día entra una sección de nombre largo. */
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	.menu-button {


### PR DESCRIPTION
David lo vio en un iPhone: en la cabecera salía **la barra separadora sola en un renglón** y «Celebridades» en el siguiente.

## La causa

El separador era **el carácter «|» dentro del texto**, así que el navegador podía partir la línea justo detrás. Pasa a ser un `border-left`: no hay carácter que separar, y de paso un lector de pantalla deja de leer «barra vertical».

## El segundo intento tampoco valía

Con eso dejaba de partirse **pero se recortaba a «Celebrida…»**, que es peor. El nombre y la sección comparten fila y el flex la comprimía.

Ya no se encoge: el nombre se reparte en dos renglones y el hueco que necesita la sección es suyo.

## Comprobado

Las **seis secciones**, los **dos idiomas** y **nueve anchos** entre 320 y 760px: ninguna se parte, se recorta ni pisa el botón del menú.

El caso más justo deja **8px de separación**, a 320px con «Editorial».

`pnpm build` 129 páginas · `pnpm check:links` OK · `pnpm verify:portadas` 178 correctas · `pnpm verify:viewer` en verde.

## Después de mergear

Sincronizar `contenido` con `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UQ3fpT2Ck2fq8HqqJ5vtr